### PR TITLE
Hide Pika while picking

### DIFF
--- a/Pika/AppDelegate.swift
+++ b/Pika/AppDelegate.swift
@@ -202,6 +202,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         notificationCenter.post(name: Notification.Name(PikaConstants.ncTriggerCopyBackground), object: self)
     }
 
+    @IBAction func fadeOutPika(_: Any) {
+        pikaWindow.fadeOut(nil)
+    }
+
+    @IBAction func fadeInPika(_: Any) {
+        pikaWindow.fadeIn(nil)
+    }
+
     @IBAction func checkForUpdates(_: Any) {
         SUUpdater.shared().feedURL = URL(string: PikaConstants.url())
         SUUpdater.shared()?.checkForUpdates(self)

--- a/Pika/Styles/EyedropperButtonStyle.swift
+++ b/Pika/Styles/EyedropperButtonStyle.swift
@@ -6,12 +6,5 @@ struct EyedropperButtonStyle: ButtonStyle {
         configuration.label
             .background(color)
             .opacity(configuration.isPressed ? 0.8 : 1.0)
-            .modify {
-                if #available(OSX 11.0, *) {
-                    $0.animation(.easeIn(duration: 0.15), value: color)
-                } else {
-                    $0
-                }
-            }
     }
 }

--- a/Pika/Utilities/Eyedroppers.swift
+++ b/Pika/Utilities/Eyedroppers.swift
@@ -27,9 +27,13 @@ class Eyedropper: ObservableObject {
 
     func start() {
         let sampler = NSColorSampler()
-        sampler.show { selectedColor in
-            if let selectedColor = selectedColor {
-                self.color = selectedColor.usingColorSpace(Defaults[.colorSpace])!
+        NSApp.sendAction(#selector(AppDelegate.fadeOutPika), to: nil, from: nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            sampler.show { selectedColor in
+                NSApp.sendAction(#selector(AppDelegate.fadeInPika), to: nil, from: nil)
+                if let selectedColor = selectedColor {
+                    self.color = selectedColor.usingColorSpace(Defaults[.colorSpace])!
+                }
             }
         }
     }

--- a/Pika/Utilities/PikaWindow.swift
+++ b/Pika/Utilities/PikaWindow.swift
@@ -15,7 +15,6 @@ class PikaWindow {
         window.isMovableByWindowBackground = true
         window.standardWindowButton(NSWindow.ButtonType.zoomButton)!.isEnabled = false
         window.titlebarAppearsTransparent = true
-        window.hasShadow = false
 
         // Set up toolbar
         window.toolbar = NSToolbar()

--- a/Pika/Utilities/PikaWindow.swift
+++ b/Pika/Utilities/PikaWindow.swift
@@ -15,6 +15,7 @@ class PikaWindow {
         window.isMovableByWindowBackground = true
         window.standardWindowButton(NSWindow.ButtonType.zoomButton)!.isEnabled = false
         window.titlebarAppearsTransparent = true
+        window.hasShadow = false
 
         // Set up toolbar
         window.toolbar = NSToolbar()


### PR DESCRIPTION
Following on from the issue raised in https://github.com/superhighfives/pika/issues/29, this PR hides Pika while color picking is taking place. You can see a video of this behaviour here—keen to get people's feedback:
https://user-images.githubusercontent.com/449385/106212467-9d90e300-61c2-11eb-8b6a-271a71d25e3f.mov