### PR TITLE
Fix for errant menubar icon (#108): Added check if window canBecomeKey before making it key

### DIFF
--- a/Pika/AppDelegate.swift
+++ b/Pika/AppDelegate.swift
@@ -33,7 +33,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 NSApp.unhide(self)
 
                 if let window = NSApp.windows.first {
-                    window.makeKeyAndOrderFront(self)
+                    // Verify window can become key before making it key and moving it to front
+                    if window.canBecomeKey {
+                        window.makeKeyAndOrderFront(self)
+                    }
                     window.setIsVisible(true)
                 }
 


### PR DESCRIPTION
This avoids the error when making statusBarItem key, since it's an NSStatusItem and can't become key. This fixes issue #108 - Pika icon shows on top of Apple menu after restart when set to "Hide menu bar icon".