### PR TITLE
Calculate contrast ratio in sRGB

### DIFF
--- a/Pika/Extensions/Cula.swift
+++ b/Pika/Extensions/Cula.swift
@@ -79,7 +79,8 @@ extension NSColor {
             (c < 0.03928) ? (c / 12.92) : pow((c + 0.055) / 1.055, 2.4)
         }
 
-        return 0.2126 * lumHelper(c: rgba.r) + 0.7152 * lumHelper(c: rgba.g) + 0.0722 * lumHelper(c: rgba.b)
+        let result = 0.2126 * lumHelper(c: rgba.r) + 0.7152 * lumHelper(c: rgba.g) + 0.0722 * lumHelper(c: rgba.b)
+        return max(.zero, result)
     }
 
     /*

--- a/Pika/Extensions/Cula.swift
+++ b/Pika/Extensions/Cula.swift
@@ -73,7 +73,7 @@ extension NSColor {
     }
 
     var luminance: CGFloat {
-        let rgba = toRGBAComponents()
+        let rgba = toRGBAComponents(in: .extendedSRGB)
 
         func lumHelper(c: CGFloat) -> CGFloat {
             (c < 0.03928) ? (c / 12.92) : pow((c + 0.055) / 1.055, 2.4)
@@ -107,10 +107,12 @@ extension NSColor {
      * RGBA
      */
 
-    final func toRGBAComponents() -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+    final func toRGBAComponents(in colorSpace: NSColorSpace = Defaults[.colorSpace])
+        -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat)
+    {
         var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
 
-        guard let rgbaColor = usingColorSpace(Defaults[.colorSpace]) else {
+        guard let rgbaColor = usingColorSpace(colorSpace) else {
             fatalError("Could not convert color to RGBA")
         }
 


### PR DESCRIPTION
Hi,

I notice that contrast ratio is only related to the value (in preferred color space) of color pair (two contrast colors). Contrast ratio of the same color pair varies by color space since colors are differently encoded. I've tested it out on *Pika* of a recent stable build (52, 1.0.2) and a recent one from source (85c3546).

WCAG 2.1 recommends sRGB for color contrast ratio:

> Almost all systems used today to view Web content assume sRGB encoding. Unless it is known that another color space will be used to process and display the content, authors should evaluate using sRGB colorspace. If using other color spaces, see [Understanding Success Criterion 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum). 

After the simple code tweak, contrast ratio will be independent of the color space and always comply with WCAG 2.1.

Color values are converted in sRGB for relative luminance. Extended range beyond [0, 1] is used so bright colors are unclamped for contrast ratio. The introduction of extended range might make negative luminance (Though I can't imagine how to trigger such bug), so luminance values are conservatively clamped to non-negative. The signature of `toRGBAComponents()` in extension of `NSColor` will changed without impact on other code.

That's it. Hope it helps the development of _Pika_!