### PR TITLE
Reorder color picker formats: Move LAB before OpenGL

### DIFF
--- a/Pika/Constants/Defaults.swift
+++ b/Pika/Constants/Defaults.swift
@@ -7,8 +7,8 @@ enum ColorFormat: String, Codable, CaseIterable, Equatable {
     case rgb = "RGB"
     case hsb = "HSB"
     case hsl = "HSL"
-    case opengl = "OpenGL"
     case lab = "LAB"
+    case opengl = "OpenGL"
 
     func getExample(color: NSColor, style: CopyFormat) -> String {
         color.toFormat(format: self, style: style)


### PR DESCRIPTION
## Summary
- Reordered color format options in the color picker
- Moved LAB format to appear before OpenGL format

## Problem
The color format ordering in the picker wasn't following the most logical sequence for user workflow.

## Solution
Repositioned LAB format to come before OpenGL in the ColorFormat enum, providing a more intuitive format ordering in the UI.

🤖 Generated with [Claude Code](https://claude.ai/code)