### PR TITLE
feat: add color overlay after picking

### DIFF
--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -124,6 +124,10 @@
 		EAF100C725C731AD006E1EC3 /* SplashTouchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF100C625C731AD006E1EC3 /* SplashTouchBar.swift */; };
 		EAF100CA25C75218006E1EC3 /* PikaTouchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF100C325C59EB3006E1EC3 /* PikaTouchBar.swift */; };
 		EAF100CD25C785C4006E1EC3 /* TouchBarVisual.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF100CC25C785C4006E1EC3 /* TouchBarVisual.swift */; };
+		F8ABAC5A2EAAD0DF008CD152 /* ColorPickOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8ABAC592EAAD0DF008CD152 /* ColorPickOverlay.swift */; };
+		F8ABAC5B2EAAD0DF008CD152 /* ColorPickOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8ABAC592EAAD0DF008CD152 /* ColorPickOverlay.swift */; };
+		F8ABAC5D2EAAD0F0008CD152 /* ColorPickOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8ABAC5C2EAAD0F0008CD152 /* ColorPickOverlayWindow.swift */; };
+		F8ABAC5E2EAAD0F0008CD152 /* ColorPickOverlayWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8ABAC5C2EAAD0F0008CD152 /* ColorPickOverlayWindow.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -202,6 +206,8 @@
 		EAF100C325C59EB3006E1EC3 /* PikaTouchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PikaTouchBar.swift; sourceTree = "<group>"; };
 		EAF100C625C731AD006E1EC3 /* SplashTouchBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplashTouchBar.swift; sourceTree = "<group>"; };
 		EAF100CC25C785C4006E1EC3 /* TouchBarVisual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBarVisual.swift; sourceTree = "<group>"; };
+		F8ABAC592EAAD0DF008CD152 /* ColorPickOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickOverlay.swift; sourceTree = "<group>"; };
+		F8ABAC5C2EAAD0F0008CD152 /* ColorPickOverlayWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickOverlayWindow.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -335,6 +341,7 @@
 			isa = PBXGroup;
 			children = (
 				EA7B199B25FBA0E600E06D9D /* ClosestVector.swift */,
+				F8ABAC5C2EAAD0F0008CD152 /* ColorPickOverlayWindow.swift */,
 				EACA8A44260501210064035C /* Exporter.swift */,
 				EAD0B6F1259CF29300FA2F67 /* Eyedroppers.swift */,
 				EA7B199525FBA08100E06D9D /* LoadColors.swift */,
@@ -353,6 +360,7 @@
 				EAD0B6F5259CF29300FA2F67 /* AppVersion.swift */,
 				22903B0228294F49004BB9F0 /* ColorExampleRow.swift */,
 				EA635DE025B4FC580014D91A /* ColorPickers.swift */,
+				F8ABAC592EAAD0DF008CD152 /* ColorPickOverlay.swift */,
 				EABAEADF284D50D1000716AE /* ComplianceButtons.swift */,
 				EA801284259F8F480026D5D9 /* ComplianceToggle.swift */,
 				EA424C7C25CDEF98009056A9 /* ComplianceToggleGroup.swift */,
@@ -622,6 +630,7 @@
 				EA635DF125B5A6D80014D91A /* Toast.swift in Sources */,
 				EAD0B71C259D151400FA2F67 /* NavigationMenu.swift in Sources */,
 				22FE80B325BA0F820063759E /* KeyboardShortcutItem.swift in Sources */,
+				F8ABAC5A2EAAD0DF008CD152 /* ColorPickOverlay.swift in Sources */,
 				EAD0B6F8259CF29300FA2F67 /* AboutView.swift in Sources */,
 				C49A11482DB394F500EE7E80 /* APCACompliance.swift in Sources */,
 				EAA8AE1925B8EC070049299B /* KeyboardShortcutKey.swift in Sources */,
@@ -632,6 +641,7 @@
 				EAD0B718259D146200FA2F67 /* EyedropperButtonStyle.swift in Sources */,
 				EA635DC925B3B2650014D91A /* Cula.swift in Sources */,
 				EAEBF64725E878A5002999D1 /* CircleButtonStyle.swift in Sources */,
+				F8ABAC5D2EAAD0F0008CD152 /* ColorPickOverlayWindow.swift in Sources */,
 				EA635DE125B4FC580014D91A /* ColorPickers.swift in Sources */,
 				EACA8A45260501210064035C /* Exporter.swift in Sources */,
 				221600F925A62E5B00B8B7D9 /* IconImage.swift in Sources */,
@@ -661,6 +671,7 @@
 				EAE23DAF2D032A38005BB270 /* OverflowContentViewModifier.swift in Sources */,
 				EAE23DB02D032A38005BB270 /* KeyboardShortcutGrid.swift in Sources */,
 				EAE2EBA32D03C40000FA9BC9 /* LatestAppStoreVersion+ShouldUpdate.swift in Sources */,
+				F8ABAC5E2EAAD0F0008CD152 /* ColorPickOverlayWindow.swift in Sources */,
 				EAE23DB12D032A38005BB270 /* AppModeToggleGroup.swift in Sources */,
 				EAE23DB22D032A38005BB270 /* Visualisation.swift in Sources */,
 				EAE23DB32D032A38005BB270 /* ContentView.swift in Sources */,
@@ -682,6 +693,7 @@
 				EAE23DC42D032A38005BB270 /* KeyboardShortcutItem.swift in Sources */,
 				EAE23DC52D032A38005BB270 /* AboutView.swift in Sources */,
 				EAE23DC62D032A38005BB270 /* KeyboardShortcutKey.swift in Sources */,
+				F8ABAC5B2EAAD0DF008CD152 /* ColorPickOverlay.swift in Sources */,
 				EAE23DC72D032A38005BB270 /* EyedropperButton.swift in Sources */,
 				EAE23DC82D032A38005BB270 /* MetalShader.metal in Sources */,
 				EAE2EB9F2D03C3DE00FA9BC9 /* LookUpAPI.swift in Sources */,

--- a/Pika/Constants/Defaults.swift
+++ b/Pika/Constants/Defaults.swift
@@ -63,4 +63,6 @@ extension Defaults.Keys {
     static let appFloating = Key<Bool>("appFloating", default: true)
     static let alwaysShowOnLaunch = Key<Bool>("alwaysShowOnLaunch", default: false)
     static let contrastStandard = Key<ContrastStandard>("contrastStandard", default: .wcag)
+    static let showColorOverlay = Key<Bool>("showColorOverlay", default: true)
+    static let colorOverlayDuration = Key<Double>("colorOverlayDuration", default: 2.0)
 }

--- a/Pika/Utilities/ColorPickOverlayWindow.swift
+++ b/Pika/Utilities/ColorPickOverlayWindow.swift
@@ -1,0 +1,84 @@
+import Cocoa
+import SwiftUI
+
+class ColorPickOverlayWindow {
+    private var panel: NSPanel?
+    private var dismissTimer: Timer?
+
+    func show(colorText: String, pickedColor: NSColor, nearCursor cursorPosition: NSPoint, duration: Double) {
+        dismiss()
+
+        let contentView = ColorPickOverlay(colorText: colorText, pickedColor: pickedColor)
+        let hostingView = NSHostingView(rootView: contentView)
+
+        hostingView.invalidateIntrinsicContentSize()
+        let intrinsicSize = hostingView.intrinsicContentSize
+        let panelWidth = intrinsicSize.width
+        let panelHeight = intrinsicSize.height
+
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: panelWidth, height: panelHeight),
+            styleMask: [.nonactivatingPanel, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+
+        panel.isFloatingPanel = true
+        panel.level = .popUpMenu
+        panel.backgroundColor = .clear
+        panel.isOpaque = false
+        panel.hasShadow = true
+        panel.titlebarAppearsTransparent = true
+        panel.titleVisibility = .hidden
+        panel.isMovable = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        panel.contentView = hostingView
+
+        let screen = NSScreen.screens.first { NSMouseInRect(cursorPosition, $0.frame, false) } ?? NSScreen.main
+
+        if let screen = screen {
+            let screenFrame = screen.visibleFrame
+            let offset: CGFloat = 20
+
+            var xPosition = cursorPosition.x - offset
+            var yPosition = cursorPosition.y - panelHeight - offset
+
+            if xPosition + panelWidth > screenFrame.maxX {
+                xPosition = cursorPosition.x - panelWidth
+            }
+
+            if xPosition < screenFrame.minX {
+                xPosition = screenFrame.minX + 10
+            }
+
+            if yPosition < screenFrame.minY {
+                yPosition = cursorPosition.y + offset
+            }
+
+            if yPosition + panelHeight > screenFrame.maxY {
+                yPosition = screenFrame.maxY - panelHeight - 10
+            }
+
+            panel.setFrame(
+                NSRect(x: xPosition, y: yPosition, width: panelWidth, height: panelHeight),
+                display: true
+            )
+        }
+
+        panel.orderFrontRegardless()
+
+        self.panel = panel
+
+        dismissTimer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
+            self?.dismiss()
+        }
+    }
+
+    func dismiss() {
+        dismissTimer?.invalidate()
+        dismissTimer = nil
+        panel?.close()
+        panel = nil
+    }
+}

--- a/Pika/Utilities/Eyedroppers.swift
+++ b/Pika/Utilities/Eyedroppers.swift
@@ -53,6 +53,7 @@ class Eyedropper: ObservableObject {
     @objc @Published public var color: NSColor
 
     var undoManager: UndoManager?
+    private var overlayWindow = ColorPickOverlayWindow()
 
     init(type: Types, color: NSColor) {
         self.type = type
@@ -117,6 +118,17 @@ class Eyedropper: ObservableObject {
             sampler.show { selectedColor in
 
                 if let selectedColor = selectedColor {
+                    if Defaults[.showColorOverlay] {
+                        let colorText = selectedColor.toFormat(format: Defaults[.colorFormat], style: Defaults[.copyFormat])
+                        let cursorPosition = NSEvent.mouseLocation
+                        self.overlayWindow.show(
+                            colorText: colorText,
+                            pickedColor: selectedColor,
+                            nearCursor: cursorPosition,
+                            duration: Defaults[.colorOverlayDuration]
+                        )
+                    }
+
                     self.set(selectedColor)
 
                     if Defaults[.copyColorOnPick] {

--- a/Pika/Views/ColorPickOverlay.swift
+++ b/Pika/Views/ColorPickOverlay.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct ColorPickOverlay: View {
+    let colorText: String
+    let pickedColor: NSColor
+
+    var body: some View {
+        Text(colorText)
+            .font(.system(size: 14, weight: .semibold, design: .monospaced))
+            .foregroundColor(pickedColor.getUIColor())
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(
+                Color(pickedColor),
+                in: RoundedRectangle(cornerRadius: 12)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(pickedColor.getUIColor().opacity(0.2), lineWidth: 1)
+            )
+            .fixedSize(horizontal: true, vertical: true)
+    }
+}
+
+struct ColorPickOverlay_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 20) {
+            ColorPickOverlay(colorText: "#232323", pickedColor: NSColor(hex: "#232323"))
+            ColorPickOverlay(colorText: "rgb(35, 35, 35)", pickedColor: NSColor(hex: "#232323"))
+            ColorPickOverlay(colorText: "hsl(0, 0%, 14%)", pickedColor: NSColor(hex: "#232323"))
+            ColorPickOverlay(colorText: "0.14 0.14 0.14", pickedColor: NSColor(hex: "#232323"))
+        }
+        .frame(width: 400, height: 400)
+    }
+}

--- a/Pika/Views/PreferencesView.swift
+++ b/Pika/Views/PreferencesView.swift
@@ -16,6 +16,8 @@ struct PreferencesView: View {
     @Default(.appFloating) var appFloating
     @Default(.alwaysShowOnLaunch) var alwaysShowOnLaunch
     @Default(.contrastStandard) var contrastStandard
+    @Default(.showColorOverlay) var showColorOverlay
+    @Default(.colorOverlayDuration) var colorOverlayDuration
     @State var colorSpace: NSColorSpace = Defaults[.colorSpace]
     @State var disableHideMenuBarIcon = true
     @State private var viewHeight: CGFloat = 0.0
@@ -132,6 +134,29 @@ struct PreferencesView: View {
                                     .frame(
                                         maxWidth: .infinity, alignment: .leading
                                     )
+                            }
+
+                            Divider()
+                                .padding(.vertical, 2.0)
+
+                            Toggle(isOn: $showColorOverlay) {
+                                Text("Show color overlay after picking")
+                            }
+
+                            if showColorOverlay {
+                                HStack(spacing: 8.0) {
+                                    Text("Duration:")
+                                        .font(.system(size: 12))
+                                    Slider(
+                                        value: $colorOverlayDuration,
+                                        in: 1.0...5.0,
+                                        step: 0.5
+                                    )
+                                    Text(String(format: "%.1fs", colorOverlayDuration))
+                                        .font(.system(size: 12, design: .monospaced))
+                                        .frame(width: 35, alignment: .trailing)
+                                }
+                                .padding(.leading, 8.0)
                             }
                         }
                         .frame(


### PR DESCRIPTION
**Summary**
This PR adds a visual confirmation overlay that appears after picking a color with the eyedropper. It shows the color value near the cursor and fades out automatically after a configurable duration.

---

**Feature**

* Shows a small overlay with the selected color in your preferred format (HEX, RGB, HSL, etc.)
* Uses the actual picked color as background with adaptive text for readability
* Smart positioning keeps it visible on screen and above the macOS magnifier

**Settings**

* Added toggle to enable/disable the overlay (on by default)
* Added duration slider (1-5s, default 2s)
* Located in **Preferences -> Selection**

---

**Why**
The native macOS picker doesn’t show the color value before selection, making it hard to confirm accuracy.
This overlay provides instant feedback of both the color and its code, making picking faster and more precise.

<img width="1420" height="652" alt="image" src="https://github.com/user-attachments/assets/5a0eaaa7-b71b-4a8c-9d23-dd4b6633525d" />
