### PR TITLE
Add Polish localization

### DIFF
--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		23EE8C0928DA24AE0042090A /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		23EE8C0A28DA3FF00042090A /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Main.strings; sourceTree = "<group>"; };
 		92D97C2125FF7A5A007CCDE4 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B581F92B2EDF40D700392413 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		B581F92C2EDF40D700392413 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/Main.strings; sourceTree = "<group>"; };
 		C1BF641E2C1AE533004D33DD /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C1BF641F2C1AE533004D33DD /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		C1BF64202C1AE53C004D33DD /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -474,6 +476,7 @@
 				es,
 				"zh-Hans",
 				"zh-Hant",
+				pl,
 			);
 			mainGroup = EAD0B6BF259CED1C00FA2F67;
 			packageReferences = (
@@ -727,6 +730,7 @@
 				223FDEEF2B038A9B000F89A0 /* es */,
 				C1BF641E2C1AE533004D33DD /* zh-Hans */,
 				C1BF64202C1AE53C004D33DD /* zh-Hant */,
+				B581F92B2EDF40D700392413 /* pl */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -741,6 +745,7 @@
 				223FDEEE2B038A9B000F89A0 /* es */,
 				C1BF641F2C1AE533004D33DD /* zh-Hans */,
 				C1BF64212C1AE53C004D33DD /* zh-Hant */,
+				B581F92C2EDF40D700392413 /* pl */,
 			);
 			name = Main.storyboard;
 			sourceTree = "<group>";

--- a/Pika/Assets/pl.lproj/Localizable.strings
+++ b/Pika/Assets/pl.lproj/Localizable.strings
@@ -1,0 +1,332 @@
+/* Pika */
+"app.name" = "Pika";
+
+/* Version */
+"app.version" = "wersja";
+
+/* Build */
+"app.build" = "kompilacja";
+
+/* Unknown */
+"app.unknown" = "nieznana";
+
+/* Designed by */
+"app.designed" = "Zaprojektowana przez:";
+
+/* Website */
+"app.website" = "Witryna";
+
+/* GitHub */
+"app.github" = "GitHub";
+
+/* Global Shortcut */
+"preferences.hotkey.title" = "Globalny skrót klawiszowy";
+
+/* Set a global hotkey shortcut to invoke Pika */
+"preferences.hotkey.description" = "Utwórz globalny skrót klawiszowy służący do wywołania Piki";
+
+/* Copy Settings */
+"preferences.copy.title" = "Kopiuj ustawienia";
+
+/* Export color for */
+"preferences.copy.export" = "Eksportuj kolor dla";
+
+/* Example output */
+"preferences.copy.export.example" = "Przykładowy wynik";
+
+/* Export Format */
+"preferences.copy.format" = "Format eksportu";
+
+/* Unformatted */
+"preferences.copy.options.unformatted" = "Bez formatowania";
+
+/* Design Application */
+"preferences.copy.options.design" = "Oprogramowanie do projektowania";
+
+/* CSS */
+"preferences.copy.options.css" = "Kaskadowe arkusze stylów (CSS)";
+
+/* SwiftUI */
+"preferences.copy.options.swiftui" = "SwiftUI";
+
+/* Automatically copy color to clipboard on pick */
+"preferences.copy.automatic" = "Po wybraniu, automatycznie kopiuj kolor do schowka";
+
+/* Color Format */
+"preferences.format.title" = "Format koloru";
+
+/* Set your preferred display format for colors */
+"preferences.format.description" = "Ustaw preferowany format wyświetlania kolorów";
+
+/* Set your RGB color space */
+"preferences.space.description" = "Ustaw profil kolorów RGB";
+
+/* System Default */
+"preferences.space.default" = "Domyślny systemu";
+
+/* Hide Pika while picking */
+"preferences.pick.hide" = "Ukryj Pikę podczas wybierania";
+
+/* General Settings */
+"preferences.general.title" = "Ustawienia ogólne";
+
+/* Selection Settings */
+"preferences.selection.title" = "Ustawienia zaznaczania";
+
+/* Hide menu bar icon */
+"preferences.icon.description" = "Ukryj ikonę paska menu";
+
+/* Launch at login */
+"preferences.launch.description" = "Uruchom podczas logowania";
+
+/* Hide color names */
+"preferences.names.description" = "Ukryj nazwy kolorów";
+
+/* Subscribe to beta releases */
+"preferences.beta.description" = "Subskrybuj wersje beta";
+
+/* Float above windows */
+"preferences.float.description" = "Pływaj ponad oknami";
+
+/* Always show Pika on launch */
+"preferences.show.description" = "Zawsze pokazuj Pikę po uruchomieniu";
+
+/* App Settings */
+"preferences.app.title" = "Ustawienia aplikacji";
+
+/* Menu bar */
+"preferences.app.menubar.title" = "Pasek menu";
+
+/* Show in menu bar */
+"preferences.app.menubar.description" = "Pokazuj w pasku menu";
+
+/* Dock */
+"preferences.app.dock.title" = "Dock";
+
+/* Show in dock */
+"preferences.app.dock.description" = "Pokazuj w Docku";
+
+/* Hidden */
+"preferences.app.hidden.title" = "Ukryte";
+
+/* Hide app */
+"preferences.app.hidden.description" = "Ukryj aplikację";
+
+/* Appearance */
+"preferences.appearance.title" = "Wygląd";
+
+/* Weight */
+"preferences.appearance.weight.title" = "Ciężar optyczny";
+
+/* View WCAG compliance by weight, from normal to large */
+"preferences.appearance.weight.description" = "Pokazuj zgodność z WCAG według ciężaru, od zwykłego do dużego";
+
+/* Contrast */
+"preferences.appearance.contrast.title" = "Kontrast";
+
+/* View WCAG compliance by contrast, from 3:1 to 7:1 */
+"preferences.appearance.contrast.description" = "Pokazuj zgodność z WCAG według kontrastu, od 3:1 do 7:1";
+
+/* Contrast Value */
+"preferences.appearance.apca.title" = "Wartość kontrastu";
+
+/* View APCA contrast value by lightness contrast (Lc), from 30 to 75 */
+"preferences.appearance.apca.description" = "Pokazuj wartość kontrastu APCA według kontrastu jasności (Lc) od 30 do 75";
+
+/* Contrast Calculation Standard */
+"preferences.contrast.standard" = "Metoda obliczania kontrastu";
+
+/* Contrast ratio */
+"color.ratio" = "Współczynnik kontrastu";
+
+/* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
+"color.ratio.description" = "Współczynnik kontrastu to miara różnicy w postrzeganej jasności dwóch kolorów, służąca do obliczenia współczynnika kontrastu.";
+
+/* Contrast Value (Lc) */
+"color.lc" = "Wartość kontrastu jasności (Lc)";
+
+/* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
+"color.lc.description" = "Kontrast jasności (Lc) to miara różnicy jasności między dwoma kolorami, służąca do obliczenia wartości kontrastu.";
+
+/* WCAG Compliance */
+"color.wcag" = "Zgodność z wytycznymi WCAG";
+
+/* APCA Contrast Reference */
+"color.apca" = "Zgodność kontrastu tekstu z wytycznymi APCA";
+
+/* Foreground */
+"color.foreground" = "Pierwszy plan";
+
+/* Background */
+"color.background" = "Tło";
+
+/* WCAG 3:1 */
+"color.wcag.30" = "Norma WCAG 2 poziomu AA wymaga współczynnika kontrastu wynoszącego co najmniej 3:1 dla tekstu dużego (18 pt / ~24 px) lub pogrubionego (14 pt / ~18,6 px), a także dla zawartości innej niż tekst, np. interfejsu użytkownika.";
+
+/* WCAG 4.5:1 */
+"color.wcag.45" = "Norma WCAG 2 poziomu AA wymaga współczynnika kontrastu co najmniej 4,5:1 dla zwykłego tekstu. Norma WCAG 2 poziomu AAA wymaga współczynnika kontrastu co najmniej 4,5:1 dla tekstu dużego (18 pt / ~24 px) lub pogrubionego (14 pt / ~18,6 px).";
+
+/* WCAG 7:1 */
+"color.wcag.70" = "Norma WCAG 2 poziomu AAA wymaga, aby w przypadku zwykłego tekstu współczynnik kontrastu wynosił co najmniej 7:1.";
+
+/* APCA 30 */
+"color.apca.30" = "APCA >= 30 to minimalny kontrast tekstu podstawowego i elementów nietekstowych. Odpowiedni dla większego tekstu, tekstów zastępczych i elementów wyłączonych.";
+
+/* APCA 45 */
+"color.apca.45" = "APCA >= 45 to minimalny kontrast tekstu nagłówkowego. Odpowiedni dla dużych nagłówków, elementów nawigacyjnych i ważnych komponentów interfejsu użytkownika.";
+
+/* APCA 60 */
+"color.apca.60" = "APCA >= 60 to minimalny kontrast tekstu tytułowego. Odpowiedni dla podtytułów, podpisów i treści drugorzędnych, które muszą być wyraźnie czytelne.";
+
+/* APCA 75 */
+"color.apca.75" = "APCA >= 75 to minimalny kontrast tekstu głównego. Odpowiedni dla treści podstawowych, tekstu o standardowym rozmiarze i obszernych materiałów do czytania.";
+
+/* Pass */
+"color.wcag.pass" = "zaliczona";
+
+/* Fail */
+"color.wcag.fail" = "niezaliczona";
+
+/* Normal */
+"color.wcag.normal" = "Zwykły";
+
+/* Large */
+"color.wcag.large" = "Duży";
+
+/* LG */
+"color.wcag.large.abbr" = "LG";
+
+/* Global shortcut */
+"splash.hotkey" = "Skrót globalny";
+
+/* Launch at login */
+"splash.launch" = "Uruchom podczas logowania";
+
+/* Get started */
+"splash.start" = "Zaczynamy";
+
+/* Pick */
+"color.pick" = "Wybierz";
+
+/* Swap */
+"color.swap" = "Zamień";
+
+/* Swap colors */
+"color.swap.detail" = "Zamień kolory";
+
+/* Undo */
+"color.undo" = "Cofnij";
+
+/* Redo */
+"color.redo" = "Przywróć";
+
+/* Pick foreground */
+"color.pick.foreground" = "Wybierz pierwszy plan";
+
+/* Pick background */
+"color.pick.background" = "Wybierz tło";
+
+/* Copy */
+"color.copy" = "Kopiuj";
+
+/* Copy foreground */
+"color.copy.foreground" = "Kopiuj pierwszy plan";
+
+/* Copy background */
+"color.copy.background" = "Kopiuj tło";
+
+/* Copy all as text */
+"color.copy.text" = "Kopiuj wszystko jako tekst";
+
+/* Copy all as JSON */
+"color.copy.data" = "Kopiuj wszystko jako JSON";
+
+/* Copied */
+"color.copy.toast" = "Skopiowano";
+
+/* Copy current format */
+"color.copy.current" = "Kopiuj bieżący format";
+
+/* Copy HEX values */
+"color.copy.hex" = "Kopiuj wartości szesnastkowe";
+
+/* Copy HSB values */
+"color.copy.hsb" = "Kopiuj wartości HSB";
+
+/* Copy HSL values */
+"color.copy.hsl" = "Kopiuj wartości HSL";
+
+/* Copy RGB values */
+"color.copy.rgb" = "Kopiuj wartości RGB";
+
+/* Copy OpenGL values */
+"color.copy.opengl" = "Kopiuj wartości OpenGL";
+
+/* Copy LAB values */
+"color.copy.lab" = "Kopiuj wartości LAB";
+
+/* System color picker */
+"color.system" = "Systemowy wybór koloru";
+
+/* Use foreground system color picker */
+"color.system.foreground" = "Wybierz pierwszy plan (system)";
+
+/* Use background system color picker */
+"color.system.background" = "Wybierz tło (system)";
+
+/* System foreground */
+"color.system.foreground.simple" = "Pierwszy plan (system)";
+
+/* System background */
+"color.system.background.simple" = "Tło (system)";
+
+/* HEX format */
+"color.format.hex" = "Format szesnastkowy";
+
+/* HSB format */
+"color.format.hsb" = "Format HSB";
+
+/* HSL format */
+"color.format.hsl" = "Format HSL";
+
+/* RGB format */
+"color.format.rgb" = "Format RGB";
+
+/* OpenGL format */
+"color.format.opengl" = "Format OpenGL";
+
+/* LAB format */
+"color.format.lab" = "Format LAB";
+
+/* Copy foreground */
+"menu.copy.foreground" = "Kopiuj pierwszy plan";
+
+/* Copy background */
+"menu.copy.background" = "Kopiuj tło";
+
+/* Export */
+"menu.export" = "Eksportuj";
+
+/* About */
+"menu.about" = "Pika…";
+
+/* Check for updates */
+"menu.updates" = "Sprawdź uaktualnienia";
+
+/* Preferences */
+"menu.preferences" = "Ustawienia";
+
+/* Pika Website */
+"menu.website" = "Witryna Piki";
+
+/* Report Bug or Feedback */
+"menu.issue" = "Prześlij opinię";
+
+/* Quit */
+"menu.quit" = "Zakończ";
+
+/* Show color overlay after picking */
+"preferences.overlay.show" = "Pokazuj chwilową nakładkę kolorystyczną po wybraniu";
+
+/* Duration: */
+"preferences.overlay.duration" = "Czas trwania";

--- a/Pika/Assets/pl.lproj/Main.strings
+++ b/Pika/Assets/pl.lproj/Main.strings
@@ -1,0 +1,120 @@
+
+/* Class = "NSMenuItem"; title = "Pika"; ObjectID = "1Xt-HY-uBw"; */
+"1Xt-HY-uBw.title" = "Pika";
+
+/* Class = "NSMenuItem"; title = "Quit Pika"; ObjectID = "4sb-4s-VLi"; */
+"4sb-4s-VLi.title" = "Zakończ Pikę";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "5QF-Oa-p0T"; */
+"5QF-Oa-p0T.title" = "Edytuj";
+
+/* Class = "NSMenuItem"; title = "About Pika"; ObjectID = "5kV-Vb-QxS"; */
+"5kV-Vb-QxS.title" = "Pika…";
+
+/* Class = "NSMenuItem"; title = "Redo"; ObjectID = "6dh-zS-Vam"; */
+"6dh-zS-Vam.title" = "Przywróć";
+
+/* Class = "NSMenuItem"; title = "Swap colors"; ObjectID = "6j0-AT-P3M"; */
+"6j0-AT-P3M.title" = "Zamień kolory";
+
+/* Class = "NSMenu"; title = "Main Menu"; ObjectID = "AYu-sK-qS6"; */
+"AYu-sK-qS6.title" = "Menu główne";
+
+/* Class = "NSMenuItem"; title = "Check for updates…"; ObjectID = "BOF-NM-1cW"; */
+"BOF-NM-1cW.title" = "Sprawdź uaktualnienia…";
+
+/* Class = "NSMenuItem"; title = "Copy all as text"; ObjectID = "D8e-06-QFY"; */
+"D8e-06-QFY.title" = "Kopiuj wszystko jako tekst";
+
+/* Class = "NSMenu"; title = "Help"; ObjectID = "F2S-fz-NVQ"; */
+"F2S-fz-NVQ.title" = "Pomoc";
+
+/* Class = "NSMenuItem"; title = "Pika website"; ObjectID = "FKE-Sm-Kum"; */
+"FKE-Sm-Kum.title" = "Witryna Piki";
+
+/* Class = "NSMenu"; title = "Eyedroppers"; ObjectID = "KHB-9b-hO2"; */
+"KHB-9b-hO2.title" = "Próbniki koloru";
+
+/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "Kd2-mp-pUS"; */
+"Kd2-mp-pUS.title" = "Pokaż wszystkie";
+
+/* Class = "NSMenuItem"; title = "Services"; ObjectID = "NMo-om-nkz"; */
+"NMo-om-nkz.title" = "Usługi";
+
+/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "NQA-cg-qc7"; */
+"NQA-cg-qc7.title" = "Preferencje…";
+
+/* Class = "NSMenuItem"; title = "Pick foreground..."; ObjectID = "Nec-cr-B3a"; */
+"Nec-cr-B3a.title" = "Wybierz kolor pierwszego planu…";
+
+/* Class = "NSMenuItem"; title = "Hide Pika"; ObjectID = "Olw-nP-bQN"; */
+"Olw-nP-bQN.title" = "Ukryj Pikę";
+
+/* Class = "NSMenuItem"; title = "Copy all as JSON"; ObjectID = "U40-Ip-3Uj"; */
+"U40-Ip-3Uj.title" = "Kopiuj wszystko jako JSON";
+
+/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "Vdr-fp-XzO"; */
+"Vdr-fp-XzO.title" = "Ukryj pozostałe";
+
+/* Class = "NSMenu"; title = "Edit"; ObjectID = "W48-6f-4Dl"; */
+"W48-6f-4Dl.title" = "Edytuj";
+
+/* Class = "NSMenuItem"; title = "Pick background..."; ObjectID = "YF5-6a-ACB"; */
+"YF5-6a-ACB.title" = "Wybierz kolor tła…";
+
+/* Class = "NSMenuItem"; title = "Eyedroppers"; ObjectID = "dNS-BC-3MB"; */
+"dNS-BC-3MB.title" = "Próbniki koloru";
+
+/* Class = "NSMenuItem"; title = "Undo"; ObjectID = "dRJ-4n-Yzg"; */
+"dRJ-4n-Yzg.title" = "Cofnij";
+
+/* Class = "NSMenu"; title = "Services"; ObjectID = "hz9-B4-Xy5"; */
+"hz9-B4-Xy5.title" = "Usługi";
+
+/* Class = "NSMenuItem"; title = "Copy background"; ObjectID = "p7U-sR-JqZ"; */
+"p7U-sR-JqZ.title" = "Kopiuj kolor tła";
+
+/* Class = "NSMenu"; title = "Pika"; ObjectID = "uQy-DD-JDr"; */
+"uQy-DD-JDr.title" = "Pika";
+
+/* Class = "NSMenuItem"; title = "Help"; ObjectID = "wpr-3q-Mcd"; */
+"wpr-3q-Mcd.title" = "Pomoc";
+
+/* Class = "NSMenuItem"; title = "Copy foreground"; ObjectID = "x3v-GG-iWU"; */
+"x3v-GG-iWU.title" = "Kopiuj kolor pierwszego planu";
+
+/* Class = "NSMenuItem"; title = "Report feedback"; ObjectID = "hxD-2G-mEq.title"; */
+"hxD-2G-mEq.title" = "Zgłoś błąd lub prześlij opinię";
+
+/* Class = "NSMenuItem"; title = "Close window"; ObjectID = "VpE-fH-2gc"; */
+"VpE-fH-2gc.title" = "Zamknij okno";
+
+/* Class = "NSMenu"; title = "Eyedroppers"; ObjectID = "z8G-HT-ae8"; */
+"z8G-HT-ae8.title" = "Próbniki koloru";
+
+/* Class = "NSMenuItem"; title = "Use system picker for foreground"; ObjectID = "hMH-To-rZ9"; */
+"hMH-To-rZ9.title" = "Użyj systemowego wyboru koloru pierwszego planu";
+
+/* Class = "NSMenuItem"; title = "Use system picker for background"; ObjectID = "CnG-MW-7x1"; */
+"CnG-MW-7x1.title" = "Użyj systemowego wyboru koloru tła";
+
+/* Class = "NSMenuItem"; title = "Format"; ObjectID = "jQ5-Ak-Ocb"; */
+"jQ5-Ak-Ocb.title" = "Format";
+
+/* Class = "NSMenuItem"; title = "Hex"; ObjectID = "rJ3-3M-xcY"; */
+"rJ3-3M-xcY.title" = "szesnastkowy";
+
+/* Class = "NSMenuItem"; title = "RGB"; ObjectID = "Jrv-mf-bNr"; */
+"Jrv-mf-bNr.title" = "RGB";
+
+/* Class = "NSMenuItem"; title = "HSB"; ObjectID = "GfU-Et-UCF"; */
+"GfU-Et-UCF.title" = "HSB";
+
+/* Class = "NSMenuItem"; title = "HSL"; ObjectID = "t7X-bM-FAM"; */
+"t7X-bM-FAM.title" = "HSL";
+
+/* Class = "NSMenuItem"; title = "OpenGL"; ObjectID = "caq-wZ-Zn0"; */
+"caq-wZ-Zn0.title" = "OpenGL";
+
+/* Class = "NSMenuItem"; title = "LAB"; ObjectID = "Nwx-nK-ndW"; */
+"Nwx-nK-ndW.title" = "LAB";


### PR DESCRIPTION
@superhighfives:

Please note that proper localization would require that certain hardcoded strings become localizable, i.e.
- `Mac App Store` and `Downloaded from the internet` in `AboutView`,
- `Baseline`, `Headline`, `Title`, `Body Text` in `ComplianceToggleGroup`.

Please also note that I have submitted Polish localization to [KeyboardShortcuts](https://github.com/sindresorhus/KeyboardShortcuts) (PR sindresorhus/KeyboardShortcuts#232). I would appreciate bumping KeyboardShortcuts' version dependency once the PR gets accepted.