### PR TITLE
Croatian additions, translations and corrections for 1.3.

### DIFF
--- a/Pika/Assets/hr.lproj/Localizable.strings
+++ b/Pika/Assets/hr.lproj/Localizable.strings
@@ -19,6 +19,12 @@
 /* GitHub */
 "app.github" = "GitHub";
 
+/* Mac App Store */
+"app.store.mas" = "Mac App Store";
+
+/* Downloaded from the internet */
+"app.store.download" = "Preuzeto s interneta";
+
 /* Global Shortcut */
 "preferences.hotkey.title" = "Globalni prečac";
 
@@ -181,6 +187,18 @@
 /* APCA 75 */
 "color.apca.75" = "APCA ≥ 75 je minimalni kontrast za glavni tekst. Pogodno za primarni sadržaj, za tekst normalne veličine i za duže materijale za čitanje.";
 
+/* Baseline */
+"color.apca.baseline" = "Osnovni tekst";
+
+/* Headline */
+"color.apca.headline" = "Naslov odlomka";
+
+/* Title */
+"color.apca.title" = "Naslov";
+
+/* Body Text */
+"color.apca.body" = "Glavni tekst";
+
 /* Pass */
 "color.wcag.pass" = "Uspjelo";
 
@@ -266,19 +284,19 @@
 "color.copy.lab" = "Kopiraj LAB vrijednosti";
 
 /* System color picker */
-"color.system" = "Sustavni birač boja";
+"color.system" = "Birač boja sustava";
 
 /* Use foreground system color picker */
-"color.system.foreground" = "Koristi sustavni birač boje za prednje boje";
+"color.system.foreground" = "Koristi birač boje sustava za prednje boje";
 
 /* Use background system color picker */
-"color.system.background" = "Koristi sustavni birač boje za boje pozadine";
+"color.system.background" = "Koristi birač boje sustava za boje pozadine";
 
 /* System foreground */
-"color.system.foreground.simple" = "Sustavna prednja boja";
+"color.system.foreground.simple" = "Prednja boja sustava";
 
 /* System background */
-"color.system.background.simple" = "Sustavna boja pozadine";
+"color.system.background.simple" = "Boja pozadine sustava";
 
 /* HEX format */
 "color.format.hex" = "Hex format";

--- a/Pika/Assets/hr.lproj/Main.strings
+++ b/Pika/Assets/hr.lproj/Main.strings
@@ -21,7 +21,7 @@
 "AYu-sK-qS6.title" = "Glavni izbornik";
 
 /* Class = "NSMenuItem"; title = "Check for updates…"; ObjectID = "BOF-NM-1cW"; */
-"BOF-NM-1cW.title" = "Traži nove verzije …";
+"BOF-NM-1cW.title" = "Traži nove verzije…";
 
 /* Class = "NSMenuItem"; title = "Copy all as text"; ObjectID = "D8e-06-QFY"; */
 "D8e-06-QFY.title" = "Kopiraj sve kao tekst";
@@ -45,7 +45,7 @@
 "NQA-cg-qc7.title" = "Postavke…";
 
 /* Class = "NSMenuItem"; title = "Pick foreground..."; ObjectID = "Nec-cr-B3a"; */
-"Nec-cr-B3a.title" = "Odaberi prednju boju …";
+"Nec-cr-B3a.title" = "Odaberi prednju boju…";
 
 /* Class = "NSMenuItem"; title = "Hide Pika"; ObjectID = "Olw-nP-bQN"; */
 "Olw-nP-bQN.title" = "Sakrij Pika";
@@ -60,7 +60,7 @@
 "W48-6f-4Dl.title" = "Uredi";
 
 /* Class = "NSMenuItem"; title = "Pick background..."; ObjectID = "YF5-6a-ACB"; */
-"YF5-6a-ACB.title" = "Odaberi pozadinu …";
+"YF5-6a-ACB.title" = "Odaberi pozadinu…";
 
 /* Class = "NSMenuItem"; title = "Eyedroppers"; ObjectID = "dNS-BC-3MB"; */
 "dNS-BC-3MB.title" = "Kapaljke";


### PR DESCRIPTION
1. Added and translated the newly added strings in the `Localizable.strings` file. Also made minor changes/improvements in the existing Croatian translations.

```
/* Mac App Store */
"app.store.mas" = "Mac App Store";

/* Downloaded from the internet */
"app.store.download" = "Preuzeto s interneta";

/* Baseline */
"color.apca.baseline" = "Osnovni tekst";

/* Headline */
"color.apca.headline" = "Naslov odlomka";

/* Title */
"color.apca.title" = "Naslov";

/* Body Text */
"color.apca.body" = "Glavni tekst";
```

2. Corrections in the `Main.strings` file:
- Corrected all ellipsis character issues in Croatian.
- The ellipsis character is now used without a preceding space.