### PR TITLE
claude/analyze-test-coverage-RP2pY

### DIFF
--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -25,6 +25,10 @@
 		CC2000000000000000000801 /* APCAComplianceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000800 /* APCAComplianceTests.swift */; };
 		CC2000000000000000000901 /* NotificationNamesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000900 /* NotificationNamesTests.swift */; };
 		CC2000000000000000000A01 /* CGFloatFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000A00 /* CGFloatFormatTests.swift */; };
+		CC2000000000000000000B01 /* ColorPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000B00 /* ColorPairTests.swift */; };
+		CC2000000000000000000C01 /* ClosestVectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000C00 /* ClosestVectorTests.swift */; };
+		CC2000000000000000000D01 /* SequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000D00 /* SequenceTests.swift */; };
+		CC2000000000000000000E01 /* ExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000E00 /* ExporterTests.swift */; };
 
 		220D5E9428DB154300B6285E /* AppModeButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220D5E9328DB154300B6285E /* AppModeButtons.swift */; };
 		220D5E9828DB158400B6285E /* AppModeToggleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220D5E9728DB158400B6285E /* AppModeToggleGroup.swift */; };
@@ -206,6 +210,10 @@
 		CC2000000000000000000800 /* APCAComplianceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APCAComplianceTests.swift; sourceTree = "<group>"; };
 		CC2000000000000000000900 /* NotificationNamesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNamesTests.swift; sourceTree = "<group>"; };
 		CC2000000000000000000A00 /* CGFloatFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGFloatFormatTests.swift; sourceTree = "<group>"; };
+		CC2000000000000000000B00 /* ColorPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPairTests.swift; sourceTree = "<group>"; };
+		CC2000000000000000000C00 /* ClosestVectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosestVectorTests.swift; sourceTree = "<group>"; };
+		CC2000000000000000000D00 /* SequenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceTests.swift; sourceTree = "<group>"; };
+		CC2000000000000000000E00 /* ExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExporterTests.swift; sourceTree = "<group>"; };
 
 		220D5E9328DB154300B6285E /* AppModeButtons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppModeButtons.swift; sourceTree = "<group>"; };
 		220D5E9728DB158400B6285E /* AppModeToggleGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppModeToggleGroup.swift; sourceTree = "<group>"; };
@@ -502,6 +510,10 @@
 				CC2000000000000000000800 /* APCAComplianceTests.swift */,
 				CC2000000000000000000900 /* NotificationNamesTests.swift */,
 				CC2000000000000000000A00 /* CGFloatFormatTests.swift */,
+				CC2000000000000000000B00 /* ColorPairTests.swift */,
+				CC2000000000000000000C00 /* ClosestVectorTests.swift */,
+				CC2000000000000000000D00 /* SequenceTests.swift */,
+				CC2000000000000000000E00 /* ExporterTests.swift */,
 			);
 			path = PikaTests;
 			sourceTree = "<group>";
@@ -1015,6 +1027,10 @@
 				CC2000000000000000000801 /* APCAComplianceTests.swift in Sources */,
 				CC2000000000000000000901 /* NotificationNamesTests.swift in Sources */,
 				CC2000000000000000000A01 /* CGFloatFormatTests.swift in Sources */,
+				CC2000000000000000000B01 /* ColorPairTests.swift in Sources */,
+				CC2000000000000000000C01 /* ClosestVectorTests.swift in Sources */,
+				CC2000000000000000000D01 /* SequenceTests.swift in Sources */,
+				CC2000000000000000000E01 /* ExporterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PikaTests/ClosestVectorTests.swift
+++ b/PikaTests/ClosestVectorTests.swift
@@ -1,0 +1,72 @@
+@testable import Pika
+import XCTest
+
+/// Tests the Euclidean-distance nearest-neighbour lookup used to resolve a
+/// picked color to its closest named color. Regressions here would show up
+/// as wrong color names in the UI and in exported JSON.
+final class ClosestVectorTests: XCTestCase {
+    // MARK: - diff()
+
+    func test_diff_identicalVectors_isZero() {
+        let cv = ClosestVector([[0, 0, 0]])
+        XCTAssertEqual(cv.diff([128, 64, 32], [128, 64, 32]), 0)
+    }
+
+    func test_diff_isSquaredEuclidean() {
+        let cv = ClosestVector([[0, 0, 0]])
+        // (10-0)^2 + (0-0)^2 + (0-0)^2 = 100
+        XCTAssertEqual(cv.diff([10, 0, 0], [0, 0, 0]), 100)
+        // (1-4)^2 + (2-6)^2 + (3-15)^2 = 9 + 16 + 144 = 169
+        XCTAssertEqual(cv.diff([1, 2, 3], [4, 6, 15]), 169)
+    }
+
+    func test_diff_isSymmetric() {
+        let cv = ClosestVector([[0, 0, 0]])
+        XCTAssertEqual(cv.diff([12, 34, 56], [78, 90, 12]),
+                       cv.diff([78, 90, 12], [12, 34, 56]))
+    }
+
+    func test_diff_handlesNegativeDifferences() {
+        let cv = ClosestVector([[0, 0, 0]])
+        // Subtractions squared — sign of the difference must not matter.
+        XCTAssertEqual(cv.diff([0, 0, 0], [10, 10, 10]),
+                       cv.diff([10, 10, 10], [0, 0, 0]))
+    }
+
+    // MARK: - compare()
+
+    func test_compare_exactMatch_returnsThatIndex() {
+        let cv = ClosestVector([[255, 0, 0], [0, 255, 0], [0, 0, 255]])
+        let green = NSColor(red: 0, green: 1, blue: 0, alpha: 1).usingColorSpace(.sRGB)!
+        XCTAssertEqual(cv.compare(green), 1)
+    }
+
+    func test_compare_returnsNearestNeighbour() {
+        // Pure red is closer to [250, 5, 5] than to either green or blue.
+        let cv = ClosestVector([[0, 255, 0], [250, 5, 5], [0, 0, 255]])
+        let red = NSColor(red: 1, green: 0, blue: 0, alpha: 1).usingColorSpace(.sRGB)!
+        XCTAssertEqual(cv.compare(red), 1)
+    }
+
+    func test_compare_tie_returnsFirstIndexEncountered() {
+        // Two entries equidistant from pure black — the loop uses strict `<`,
+        // so the first entry inserted wins.
+        let cv = ClosestVector([[10, 0, 0], [0, 10, 0]])
+        let black = NSColor(red: 0, green: 0, blue: 0, alpha: 1).usingColorSpace(.sRGB)!
+        XCTAssertEqual(cv.compare(black), 0)
+    }
+
+    func test_compare_singleEntryList_alwaysReturnsZero() {
+        let cv = ClosestVector([[128, 128, 128]])
+        let white = NSColor(red: 1, green: 1, blue: 1, alpha: 1).usingColorSpace(.sRGB)!
+        XCTAssertEqual(cv.compare(white), 0)
+    }
+
+    func test_compare_normalizesColorToSRGB() {
+        // A Display P3 red should still resolve to the sRGB-red bucket after
+        // the internal `usingColorSpace(.sRGB)` normalisation.
+        let cv = ClosestVector([[0, 0, 0], [255, 0, 0], [0, 255, 0]])
+        let p3Red = NSColor(colorSpace: .displayP3, components: [1.0, 0.0, 0.0, 1.0], count: 4)
+        XCTAssertEqual(cv.compare(p3Red), 1)
+    }
+}

--- a/PikaTests/ColorPairTests.swift
+++ b/PikaTests/ColorPairTests.swift
@@ -1,0 +1,114 @@
+import Defaults
+@testable import Pika
+import XCTest
+
+/// Tests the hex-to-NSColor conversion and round-trip behaviour of ColorPair.
+/// ColorPair is the on-disk representation of a swatch in the auto-history
+/// and saved palettes, so drift here would corrupt user-visible history.
+final class ColorPairTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        Defaults[.colorSpace] = .sRGB
+    }
+
+    // MARK: - Construction and identity
+
+    func test_equality_ignoresIdAndDate() {
+        let a = ColorPair(id: UUID(), foregroundHex: "#ff0000", backgroundHex: "#00ff00", date: Date())
+        let b = ColorPair(id: UUID(), foregroundHex: "#ff0000", backgroundHex: "#00ff00",
+                          date: Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(a, b)
+    }
+
+    func test_equality_distinguishesByHex() {
+        let a = ColorPair(id: UUID(), foregroundHex: "#ff0000", backgroundHex: "#00ff00", date: Date())
+        let b = ColorPair(id: UUID(), foregroundHex: "#ff0001", backgroundHex: "#00ff00", date: Date())
+        XCTAssertNotEqual(a, b)
+    }
+
+    // MARK: - foregroundColor / backgroundColor
+
+    func test_foregroundColor_parsesHashedHex() {
+        let pair = ColorPair(id: UUID(), foregroundHex: "#ff0000", backgroundHex: "#000000", date: Date())
+        let color = pair.foregroundColor.usingColorSpace(.sRGB)!
+        XCTAssertEqual(color.redComponent, 1.0, accuracy: 0.001)
+        XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+        XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+    }
+
+    func test_backgroundColor_parsesUnhashedHex() {
+        let pair = ColorPair(id: UUID(), foregroundHex: "#000000", backgroundHex: "0000ff", date: Date())
+        let color = pair.backgroundColor.usingColorSpace(.sRGB)!
+        XCTAssertEqual(color.redComponent, 0.0, accuracy: 0.001)
+        XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+        XCTAssertEqual(color.blueComponent, 1.0, accuracy: 0.001)
+    }
+
+    func test_hexRoundTrip_noChannelDrift() {
+        // Stored hex should reconstruct to a color whose re-serialized hex matches.
+        let original = "#3a7bd5"
+        let pair = ColorPair(id: UUID(), foregroundHex: original, backgroundHex: "#000000", date: Date())
+        XCTAssertEqual(pair.foregroundColor.toHexString(style: .css), original)
+    }
+
+    // MARK: - Malformed input
+
+    func test_invalidLength_fallsBackToBlack() {
+        let pair = ColorPair(id: UUID(), foregroundHex: "#abc", backgroundHex: "#000000", date: Date())
+        let color = pair.foregroundColor.usingColorSpace(.sRGB)!
+        XCTAssertEqual(color.redComponent, 0.0, accuracy: 0.001)
+        XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+        XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+    }
+
+    func test_emptyHex_fallsBackToBlack() {
+        let pair = ColorPair(id: UUID(), foregroundHex: "", backgroundHex: "#000000", date: Date())
+        let color = pair.foregroundColor.usingColorSpace(.sRGB)!
+        XCTAssertEqual(color.redComponent, 0.0, accuracy: 0.001)
+        XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+        XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+    }
+
+    func test_nonHexCharacters_fallBackToBlack() {
+        let pair = ColorPair(id: UUID(), foregroundHex: "#zzzzzz", backgroundHex: "#000000", date: Date())
+        let color = pair.foregroundColor.usingColorSpace(.sRGB)!
+        XCTAssertEqual(color.redComponent, 0.0, accuracy: 0.001)
+        XCTAssertEqual(color.greenComponent, 0.0, accuracy: 0.001)
+        XCTAssertEqual(color.blueComponent, 0.0, accuracy: 0.001)
+    }
+
+    // MARK: - Codable
+
+    func test_isCodable_roundTripsThroughJSON() throws {
+        let original = ColorPair(
+            id: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            foregroundHex: "#123456",
+            backgroundHex: "#abcdef",
+            date: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ColorPair.self, from: data)
+        XCTAssertEqual(decoded.id, original.id)
+        XCTAssertEqual(decoded.foregroundHex, original.foregroundHex)
+        XCTAssertEqual(decoded.backgroundHex, original.backgroundHex)
+        XCTAssertEqual(decoded.date.timeIntervalSince1970, original.date.timeIntervalSince1970, accuracy: 0.001)
+    }
+
+    // MARK: - Palette
+
+    func test_palette_isAutoHistory_whenNameIsNil() {
+        let palette = Palette(id: UUID(), name: nil, pairs: [], createdAt: Date())
+        XCTAssertTrue(palette.isAutoHistory)
+    }
+
+    func test_palette_isAutoHistory_falseWhenNamed() {
+        let palette = Palette(id: UUID(), name: "Brand", pairs: [], createdAt: Date())
+        XCTAssertFalse(palette.isAutoHistory)
+    }
+
+    func test_maxHistory_is20() {
+        // Changing this bound without auditing the history/undo stack truncation
+        // logic in Eyedroppers would silently drop user data.
+        XCTAssertEqual(ColorPair.maxHistory, 20)
+    }
+}

--- a/PikaTests/ExporterTests.swift
+++ b/PikaTests/ExporterTests.swift
@@ -1,0 +1,102 @@
+@testable import Pika
+import XCTest
+
+/// Tests the palette-to-JSON export contract. Users rely on this format when
+/// exporting swatches, so the shape and field names are a public contract.
+///
+/// `Exporter.toText` and `Exporter.toJSON` take `Eyedropper` values whose
+/// initialiser force-unwraps `loadColors()`, which reads `ColorNames.json`
+/// from `Bundle.main`. That bundle is not populated in the XCTest host, so
+/// those paths are out of reach from a unit test without an app-bundle
+/// fixture. Coverage for them belongs in an integration/UI test target.
+final class ExporterTests: XCTestCase {
+    private func makePair(fg: String, bg: String, date: Date) -> ColorPair {
+        ColorPair(id: UUID(), foregroundHex: fg, backgroundHex: bg, date: date)
+    }
+
+    private func decode(_ json: String) throws -> [String: Any] {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let obj = try JSONSerialization.jsonObject(with: data)
+        return try XCTUnwrap(obj as? [String: Any])
+    }
+
+    // MARK: - paletteToJSON: named palette
+
+    func test_paletteToJSON_namedPalette_usesProvidedName() throws {
+        let pair = makePair(fg: "#ff0000", bg: "#00ff00", date: Date(timeIntervalSince1970: 0))
+        let json = Exporter.paletteToJSON(pairs: [pair], name: "Brand")
+        let parsed = try decode(json)
+        XCTAssertEqual(parsed["name"] as? String, "Brand")
+    }
+
+    func test_paletteToJSON_namedPalette_omitsDateField() throws {
+        // Named palettes intentionally strip creation dates — users shouldn't
+        // see internal timestamps in shareable exports.
+        let pair = makePair(fg: "#ff0000", bg: "#00ff00", date: Date(timeIntervalSince1970: 1_700_000_000))
+        let json = Exporter.paletteToJSON(pairs: [pair], name: "Brand")
+        let parsed = try decode(json)
+        let colors = try XCTUnwrap(parsed["colors"] as? [[String: String]])
+        XCTAssertEqual(colors.count, 1)
+        XCTAssertNil(colors[0]["date"])
+        XCTAssertEqual(colors[0]["foreground"], "#ff0000")
+        XCTAssertEqual(colors[0]["background"], "#00ff00")
+    }
+
+    // MARK: - paletteToJSON: auto-history (nil name)
+
+    func test_paletteToJSON_nilName_fallsBackToColorHistoryLabel() throws {
+        let pair = makePair(fg: "#ff0000", bg: "#00ff00", date: Date(timeIntervalSince1970: 0))
+        let json = Exporter.paletteToJSON(pairs: [pair], name: nil)
+        let parsed = try decode(json)
+        XCTAssertEqual(parsed["name"] as? String, "Color History")
+    }
+
+    func test_paletteToJSON_nilName_includesISO8601Dates() throws {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let pair = makePair(fg: "#123456", bg: "#abcdef", date: date)
+        let json = Exporter.paletteToJSON(pairs: [pair], name: nil)
+        let parsed = try decode(json)
+        let colors = try XCTUnwrap(parsed["colors"] as? [[String: String]])
+        XCTAssertEqual(colors.count, 1)
+
+        let dateString = try XCTUnwrap(colors[0]["date"])
+        let parsedDate = try XCTUnwrap(ISO8601DateFormatter().date(from: dateString))
+        XCTAssertEqual(parsedDate.timeIntervalSince1970, date.timeIntervalSince1970, accuracy: 1.0)
+    }
+
+    // MARK: - paletteToJSON: ordering and shape
+
+    func test_paletteToJSON_preservesOrderOfPairs() throws {
+        let pairs = [
+            makePair(fg: "#111111", bg: "#222222", date: Date(timeIntervalSince1970: 0)),
+            makePair(fg: "#333333", bg: "#444444", date: Date(timeIntervalSince1970: 1)),
+            makePair(fg: "#555555", bg: "#666666", date: Date(timeIntervalSince1970: 2)),
+        ]
+        let json = Exporter.paletteToJSON(pairs: pairs, name: "Ordered")
+        let parsed = try decode(json)
+        let colors = try XCTUnwrap(parsed["colors"] as? [[String: String]])
+        XCTAssertEqual(colors.map { $0["foreground"] }, ["#111111", "#333333", "#555555"])
+        XCTAssertEqual(colors.map { $0["background"] }, ["#222222", "#444444", "#666666"])
+    }
+
+    func test_paletteToJSON_emptyPairs_producesEmptyColorsArray() throws {
+        let json = Exporter.paletteToJSON(pairs: [], name: "Empty")
+        let parsed = try decode(json)
+        let colors = try XCTUnwrap(parsed["colors"] as? [[String: String]])
+        XCTAssertEqual(parsed["name"] as? String, "Empty")
+        XCTAssertTrue(colors.isEmpty)
+    }
+
+    func test_paletteToJSON_outputIsPrettyPrintedAndSorted() {
+        // The implementation asks JSONSerialization for both `.prettyPrinted`
+        // and `.sortedKeys`. Preserve that contract so CLI diffs of exported
+        // palettes stay stable.
+        let pair = makePair(fg: "#ff0000", bg: "#00ff00", date: Date(timeIntervalSince1970: 0))
+        let json = Exporter.paletteToJSON(pairs: [pair], name: "Brand")
+        XCTAssertTrue(json.contains("\n"), "Output should be pretty-printed across multiple lines")
+        // `colors` sorts alphabetically before `name` when sortedKeys is on.
+        let colorsIndex = json.range(of: "\"colors\"")!.lowerBound
+        let nameIndex = json.range(of: "\"name\"")!.lowerBound
+        XCTAssertLessThan(colorsIndex, nameIndex, "Keys should be alphabetically sorted")
+    }
+}

--- a/PikaTests/ExporterTests.swift
+++ b/PikaTests/ExporterTests.swift
@@ -87,7 +87,7 @@ final class ExporterTests: XCTestCase {
         XCTAssertTrue(colors.isEmpty)
     }
 
-    func test_paletteToJSON_outputIsPrettyPrintedAndSorted() {
+    func test_paletteToJSON_outputIsPrettyPrintedAndSorted() throws {
         // The implementation asks JSONSerialization for both `.prettyPrinted`
         // and `.sortedKeys`. Preserve that contract so CLI diffs of exported
         // palettes stay stable.
@@ -95,8 +95,9 @@ final class ExporterTests: XCTestCase {
         let json = Exporter.paletteToJSON(pairs: [pair], name: "Brand")
         XCTAssertTrue(json.contains("\n"), "Output should be pretty-printed across multiple lines")
         // `colors` sorts alphabetically before `name` when sortedKeys is on.
-        let colorsIndex = json.range(of: "\"colors\"")!.lowerBound
-        let nameIndex = json.range(of: "\"name\"")!.lowerBound
-        XCTAssertLessThan(colorsIndex, nameIndex, "Keys should be alphabetically sorted")
+        let colorsRange = try XCTUnwrap(json.range(of: "\"colors\""))
+        let nameRange = try XCTUnwrap(json.range(of: "\"name\""))
+        XCTAssertLessThan(colorsRange.lowerBound, nameRange.lowerBound,
+                          "Keys should be alphabetically sorted")
     }
 }

--- a/PikaTests/SequenceTests.swift
+++ b/PikaTests/SequenceTests.swift
@@ -1,0 +1,39 @@
+@testable import Pika
+import XCTest
+
+/// Tests the generic `unique()` helper on Sequence. Used by history and
+/// palette code to de-duplicate color entries while preserving order.
+final class SequenceTests: XCTestCase {
+    func test_unique_emptySequence_returnsEmpty() {
+        let result: [Int] = [].unique()
+        XCTAssertEqual(result, [])
+    }
+
+    func test_unique_allDistinct_preservesOrderAndCount() {
+        XCTAssertEqual([1, 2, 3, 4].unique(), [1, 2, 3, 4])
+    }
+
+    func test_unique_removesDuplicates_preservingFirstOccurrence() {
+        XCTAssertEqual([1, 2, 1, 3, 2, 4].unique(), [1, 2, 3, 4])
+    }
+
+    func test_unique_allIdentical_returnsSingleElement() {
+        XCTAssertEqual([7, 7, 7, 7].unique(), [7])
+    }
+
+    func test_unique_onStrings() {
+        XCTAssertEqual(["a", "b", "a", "c", "b"].unique(), ["a", "b", "c"])
+    }
+
+    func test_unique_onHexLikeStrings_caseSensitive() {
+        // #FF0000 and #ff0000 are different hashables — de-duplication must
+        // respect case so we don't silently merge distinct entries.
+        XCTAssertEqual(["#ff0000", "#FF0000", "#ff0000"].unique(), ["#ff0000", "#FF0000"])
+    }
+
+    func test_unique_doesNotMutateSource() {
+        let source = [1, 1, 2, 2, 3]
+        _ = source.unique()
+        XCTAssertEqual(source, [1, 1, 2, 2, 3])
+    }
+}


### PR DESCRIPTION
Covers previously-untested pure-logic code in the Services/ layer and the
Sequence extension. ExporterTests focuses on paletteToJSON (the toText/toJSON
paths require an Eyedropper, whose init reads ColorNames.json from
Bundle.main and is out of reach from the XCTest host).

https://claude.ai/code/session_01JcvsVeuayd5NE72hbntxbK