### PR TITLE
Add automated workflow to update color names

### DIFF
--- a/.github/workflows/update-color-names.yml
+++ b/.github/workflows/update-color-names.yml
@@ -21,10 +21,10 @@ jobs:
       - name: Fetch and transform upstream list
         run: |
           set -euo pipefail
-          curl --fail --retry 3 --retry-delay 5 -sSL \
+          curl --fail --retry 3 --retry-delay 5 --retry-all-errors --max-time 60 -sSL \
             https://unpkg.com/color-name-list/dist/colornames.bestof.json \
             -o upstream.json
-          jq '{colors: [.[] | {name, hex}]}' upstream.json > Pika/Assets/ColorNames.json
+          jq -c '{colors: [.[] | {name, hex}]}' upstream.json > Pika/Assets/ColorNames.json
           rm upstream.json
 
       - name: Open pull request if changed

--- a/.github/workflows/update-color-names.yml
+++ b/.github/workflows/update-color-names.yml
@@ -1,0 +1,40 @@
+name: Update Color Names
+
+on:
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    name: Fetch latest color names
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Fetch and transform upstream list
+        run: |
+          set -euo pipefail
+          curl --fail --retry 3 --retry-delay 5 -sSL \
+            https://unpkg.com/color-name-list/dist/colornames.bestof.json \
+            -o upstream.json
+          jq '{colors: [.[] | {name, hex}]}' upstream.json > Pika/Assets/ColorNames.json
+          rm upstream.json
+
+      - name: Open pull request if changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/update-color-names
+          commit-message: "chore: update ColorNames.json from color-name-list"
+          title: "chore: update ColorNames.json"
+          body: |
+            Automated refresh of `Pika/Assets/ColorNames.json` from
+            [color-name-list](https://unpkg.com/color-name-list/dist/colornames.bestof.json).
+          labels: dependencies
+          add-paths: Pika/Assets/ColorNames.json


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically fetches and updates the color names list from the upstream `color-name-list` package on a weekly schedule.

## Key Changes
- Added `.github/workflows/update-color-names.yml` workflow that:
  - Runs on a weekly schedule (Mondays at 12:00 UTC) and can be triggered manually
  - Fetches the latest color names from the `color-name-list` npm package
  - Transforms the upstream JSON format to extract only `name` and `hex` fields
  - Automatically creates a pull request if changes are detected
  - Labels the PR with `dependencies` for easy tracking

## Implementation Details
- Uses `curl` with retry logic to reliably fetch the upstream data
- Leverages `jq` to transform the JSON structure into the expected format (`Pika/Assets/ColorNames.json`)
- Employs `peter-evans/create-pull-request` action to handle PR creation with proper commit messages and branch management
- Includes appropriate permissions for writing contents and creating pull requests

https://claude.ai/code/session_01NMDcF7Vn3FNvKGD1WepQ4j