### PR TITLE
Localize contrast ratio decimal separator in UI display

### DIFF
--- a/Pika/Extensions/NSColor+Luminance.swift
+++ b/Pika/Extensions/NSColor+Luminance.swift
@@ -33,9 +33,10 @@ extension NSColor {
         Double(round(100 * contrastRatio(with: color)) / 100).description as String
     }
 
-    func toLocalizedContrastRatioString(with color: NSColor) -> String {
+    func toLocalizedContrastRatioString(with color: NSColor, locale: Locale = .current) -> String {
         let value = round(100 * contrastRatio(with: color)) / 100
         let numberFormatter = NumberFormatter()
+        numberFormatter.locale = locale
         numberFormatter.numberStyle = .decimal
         numberFormatter.minimumFractionDigits = 0
         numberFormatter.maximumFractionDigits = 2

--- a/Pika/Extensions/NSColor+Luminance.swift
+++ b/Pika/Extensions/NSColor+Luminance.swift
@@ -32,4 +32,13 @@ extension NSColor {
     func toContrastRatioString(with color: NSColor) -> String {
         Double(round(100 * contrastRatio(with: color)) / 100).description as String
     }
+
+    func toLocalizedContrastRatioString(with color: NSColor) -> String {
+        let value = round(100 * contrastRatio(with: color)) / 100
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        numberFormatter.minimumFractionDigits = 0
+        numberFormatter.maximumFractionDigits = 2
+        return numberFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
 }

--- a/Pika/Extensions/NSColor+Luminance.swift
+++ b/Pika/Extensions/NSColor+Luminance.swift
@@ -38,7 +38,7 @@ extension NSColor {
         let numberFormatter = NumberFormatter()
         numberFormatter.locale = locale
         numberFormatter.numberStyle = .decimal
-        numberFormatter.minimumFractionDigits = 0
+        numberFormatter.minimumFractionDigits = 1
         numberFormatter.maximumFractionDigits = 2
         return numberFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
     }

--- a/Pika/TouchBar/PikaTouchBar.swift
+++ b/Pika/TouchBar/PikaTouchBar.swift
@@ -135,7 +135,7 @@ class PikaTouchBarController: NSWindowController, NSTouchBarDelegate {
 
         let updateContrastText = {
             textField.stringValue = self.contrastStandard == .wcag ?
-                foreground.color.toContrastRatioString(with: background.color) :
+                foreground.color.toLocalizedContrastRatioString(with: background.color) :
                 foreground.color.toAPCAcontrastValue(with: background.color)
         }
 

--- a/Pika/Views/Footer.swift
+++ b/Pika/Views/Footer.swift
@@ -9,7 +9,7 @@ struct Footer: View {
 
     private var contrastRatioString: String {
         contrastStandard == .wcag
-            ? foreground.color.toContrastRatioString(with: background.color)
+            ? foreground.color.toLocalizedContrastRatioString(with: background.color)
             : foreground.color.toAPCAcontrastValue(with: background.color)
     }
 

--- a/PikaTests/NSColorLuminanceTests.swift
+++ b/PikaTests/NSColorLuminanceTests.swift
@@ -111,4 +111,24 @@ final class NSColorLuminanceTests: XCTestCase {
         let result = white.toContrastRatioString(with: gray)
         XCTAssertNotNil(Double(result), "Expected numeric string, got '\(result)'")
     }
+
+    // MARK: - toLocalizedContrastRatioString(with:)
+
+    func test_toLocalizedContrastRatioString_whiteOnBlack_returns21() {
+        let white = NSColor(r: 1, g: 1, b: 1)
+        let black = NSColor(r: 0, g: 0, b: 0)
+        let result = white.toLocalizedContrastRatioString(with: black)
+        XCTAssertTrue(result.hasPrefix("21"), "Expected '21...', got '\(result)'")
+    }
+
+    func test_toLocalizedContrastRatioString_usesLocaleDecimalSeparator() {
+        let white = NSColor(r: 1, g: 1, b: 1)
+        let gray = NSColor(r: 128, g: 128, b: 128)
+        let result = white.toLocalizedContrastRatioString(with: gray)
+        let separator = Locale.current.decimalSeparator ?? "."
+        XCTAssertTrue(
+            result.contains(separator) || !result.contains("."),
+            "Expected locale separator '\(separator)' in '\(result)'"
+        )
+    }
 }

--- a/PikaTests/NSColorLuminanceTests.swift
+++ b/PikaTests/NSColorLuminanceTests.swift
@@ -121,14 +121,19 @@ final class NSColorLuminanceTests: XCTestCase {
         XCTAssertTrue(result.hasPrefix("21"), "Expected '21...', got '\(result)'")
     }
 
-    func test_toLocalizedContrastRatioString_usesLocaleDecimalSeparator() {
+    func test_toLocalizedContrastRatioString_commaLocale_usesCommaSeparator() {
         let white = NSColor(r: 1, g: 1, b: 1)
         let gray = NSColor(r: 128, g: 128, b: 128)
-        let result = white.toLocalizedContrastRatioString(with: gray)
-        let separator = Locale.current.decimalSeparator ?? "."
-        XCTAssertTrue(
-            result.contains(separator) || !result.contains("."),
-            "Expected locale separator '\(separator)' in '\(result)'"
-        )
+        let result = white.toLocalizedContrastRatioString(with: gray, locale: Locale(identifier: "fr_FR"))
+        XCTAssertTrue(result.contains(","), "Expected comma decimal separator in '\(result)'")
+        XCTAssertFalse(result.contains("."), "Did not expect period decimal separator in '\(result)'")
+    }
+
+    func test_toLocalizedContrastRatioString_periodLocale_usesPeriodSeparator() {
+        let white = NSColor(r: 1, g: 1, b: 1)
+        let gray = NSColor(r: 128, g: 128, b: 128)
+        let result = white.toLocalizedContrastRatioString(with: gray, locale: Locale(identifier: "en_US"))
+        XCTAssertTrue(result.contains("."), "Expected period decimal separator in '\(result)'")
+        XCTAssertFalse(result.contains(","), "Did not expect comma decimal separator in '\(result)'")
     }
 }


### PR DESCRIPTION
Closes #219

## Summary

The contrast ratio value shown in the footer and Touch Bar was formatted with a hardcoded period decimal separator. Locales that use a comma (e.g. Croatian "Omjer kontrasta", German, French) saw `17.09 : 1` instead of the expected `17,09 : 1`.

## Changes

- Add `NSColor.toLocalizedContrastRatioString(with:)` using `NumberFormatter` (mirrors the existing APCA pattern in `toAPCAcontrastValue`).
- Use the new method in `Footer.swift` and `PikaTouchBar.swift` where the value is rendered to the user.
- Leave the existing `toContrastRatioString` in place for `Exporter` (text + JSON copy formats) so machine-readable output remains locale-independent.
- Add tests covering the new method.

## Test plan

- [ ] Set system language to Croatian (or any locale with comma as decimal separator), open Pika and verify the footer shows e.g. `17,09 : 1`.
- [ ] Verify English locale still displays `17.09 : 1`.
- [ ] Verify Touch Bar contrast readout matches the in-app footer.
- [ ] Verify copy-as-text / copy-as-JSON still produce period-separated ratios.
- [ ] `xcodebuild test` passes existing + new `NSColorLuminanceTests`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsoBpRfT4RMivQE8QJHwV2)_