### PR TITLE
Persist main window size and position across launches

### DIFF
--- a/Pika/Services/PikaWindow.swift
+++ b/Pika/Services/PikaWindow.swift
@@ -3,6 +3,11 @@ import Defaults
 import SwiftUI
 
 class PikaWindow {
+    /// Autosave name for the primary window's frame. Shared so the value set here and
+    /// re-asserted on the window's `NSWindowController` (in `WindowCoordinator`) can
+    /// never drift apart — a mismatch would silently break restore/autosave.
+    static let primaryWindowAutosaveName = NSWindow.FrameAutosaveName("Pika Window")
+
     static func createPrimaryWindow() -> NSWindow {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 480, height: 280),
@@ -39,9 +44,8 @@ class PikaWindow {
         // Note: the autosave name set here is re-asserted on the window's
         // `NSWindowController` (see `WindowCoordinator.setupMainWindow`), because
         // taking ownership of the window otherwise clears it and disables autosave.
-        let autosaveName = NSWindow.FrameAutosaveName("Pika Window")
-        let didRestoreFrame = window.setFrameUsingName(autosaveName)
-        window.setFrameAutosaveName(autosaveName)
+        let didRestoreFrame = window.setFrameUsingName(primaryWindowAutosaveName)
+        window.setFrameAutosaveName(primaryWindowAutosaveName)
         if !didRestoreFrame {
             window.center()
         }

--- a/Pika/Services/PikaWindow.swift
+++ b/Pika/Services/PikaWindow.swift
@@ -36,8 +36,9 @@ class PikaWindow {
         // Restore the previously saved frame so size and position survive quitting
         // and reopening. `setFrameAutosaveName` alone does not reliably re-apply a
         // saved frame, so restore it explicitly and only center on first launch.
-        // From here on AppKit keeps the frame in sync with user defaults as the
-        // user moves or resizes the window.
+        // Note: the autosave name set here is re-asserted on the window's
+        // `NSWindowController` (see `WindowCoordinator.setupMainWindow`), because
+        // taking ownership of the window otherwise clears it and disables autosave.
         let autosaveName = NSWindow.FrameAutosaveName("Pika Window")
         let didRestoreFrame = window.setFrameUsingName(autosaveName)
         window.setFrameAutosaveName(autosaveName)

--- a/Pika/Services/PikaWindow.swift
+++ b/Pika/Services/PikaWindow.swift
@@ -5,13 +5,12 @@ import SwiftUI
 class PikaWindow {
     static func createPrimaryWindow() -> NSWindow {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 380, height: 150),
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 280),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
         window.isReleasedWhenClosed = false
-        window.center()
         window.title = PikaText.textAppName
         window.titleVisibility = .hidden
         window.level = Defaults[.appFloating] ? .floating : .normal
@@ -34,8 +33,18 @@ class PikaWindow {
         titlebarAccessory.layoutAttribute = .trailing
         window.addTitlebarAccessoryViewController(titlebarAccessory)
 
-        // Frame and content set up
-        window.setFrameAutosaveName("Pika Window")
+        // Restore the previously saved frame so size and position survive quitting
+        // and reopening. `setFrameAutosaveName` alone does not reliably re-apply a
+        // saved frame, so restore it explicitly and only center on first launch.
+        // From here on AppKit keeps the frame in sync with user defaults as the
+        // user moves or resizes the window.
+        let autosaveName = NSWindow.FrameAutosaveName("Pika Window")
+        let didRestoreFrame = window.setFrameUsingName(autosaveName)
+        window.setFrameAutosaveName(autosaveName)
+        if !didRestoreFrame {
+            window.center()
+        }
+
         return window
     }
 

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -23,6 +23,12 @@ class WindowCoordinator: NSObject {
         self.eyedroppers = eyedroppers
         pikaWindow = PikaWindow.createPrimaryWindow()
         pikaTouchBarController = PikaTouchBarController(window: pikaWindow)
+        // `PikaTouchBarController` is an `NSWindowController`, and taking ownership of
+        // the window resets its `frameAutosaveName` to the controller's own (empty)
+        // `windowFrameAutosaveName`, wiping the name set in `createPrimaryWindow` and
+        // silently disabling frame autosave. Assign the name on the controller so it
+        // sticks and AppKit persists size/position on move and resize.
+        pikaTouchBarController.windowFrameAutosaveName = "Pika Window"
     }
 
     /// Mounts the SwiftUI content tree on the main window. Call only when the active mode
@@ -156,6 +162,11 @@ class WindowCoordinator: NSObject {
             size: NSRect(x: 0, y: 0, width: 650, height: 380),
             styleMask: [.titled, .fullSizeContentView]
         )
+        // `createSecondaryWindow` derives the autosave name from the title, which for
+        // the splash ("Pika") collides with the main window's "Pika Window" name and
+        // would let the transient, always-centered splash pollute the persisted main
+        // window frame. The splash never needs to remember its position, so clear it.
+        splashWindow.setFrameAutosaveName("")
         splashWindow.titlebarAppearsTransparent = true
         splashTouchBarController = SplashTouchBarController(window: splashWindow)
         splashWindow.contentView = NSHostingView(rootView: SplashView().edgesIgnoringSafeArea(.all))

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -39,7 +39,13 @@ class WindowCoordinator: NSObject {
                    idealHeight: 280,
                    maxHeight: 400,
                    alignment: .center)
-        pikaWindow.contentView = NSHostingView(rootView: contentView)
+        let hostingView = NSHostingView(rootView: contentView)
+        // Apply the SwiftUI min/max as the window's resize limits, but omit
+        // `.intrinsicContentSize` so the hosting view doesn't snap the window back
+        // to its ideal size on install — that would clobber the frame restored from
+        // user defaults each launch and defeat window persistence.
+        hostingView.sizingOptions = [.minSize, .maxSize]
+        pikaWindow.contentView = hostingView
     }
 
     func removeMainWindowContent() {

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -28,7 +28,7 @@ class WindowCoordinator: NSObject {
         // `windowFrameAutosaveName`, wiping the name set in `createPrimaryWindow` and
         // silently disabling frame autosave. Assign the name on the controller so it
         // sticks and AppKit persists size/position on move and resize.
-        pikaTouchBarController.windowFrameAutosaveName = "Pika Window"
+        pikaTouchBarController.windowFrameAutosaveName = PikaWindow.primaryWindowAutosaveName
     }
 
     /// Mounts the SwiftUI content tree on the main window. Call only when the active mode


### PR DESCRIPTION
## Problem

Pika's main window doesn't remember its size or position when you quit and reopen it — it always comes back centered at the default size, even if you resized or moved it.

## Root cause

The window *tried* to persist its frame via `setFrameAutosaveName("Pika Window")`, but two things defeated it:

1. **The frame was never explicitly restored, and `center()` ran unconditionally.** `window.center()` was called on every launch, and `setFrameAutosaveName` on its own does not reliably re-apply a previously saved frame — so the window kept opening centered.
2. **The SwiftUI content view snapped the window back to its ideal size.** `installMainWindowContent()` assigns an `NSHostingView` whose default `sizingOptions` (`.standardBounds`, which includes `.intrinsicContentSize`) forces the window to the view's *ideal* size (480×280) the instant it's installed — clobbering any restored or user-chosen size right after launch.

Net effect: a window resized to, say, 600×350 and moved reopens centered at 480×280.

## Fix

- **`PikaWindow.createPrimaryWindow`** — restore the saved frame explicitly with `setFrameUsingName`, then enable autosaving with `setFrameAutosaveName`, and only fall back to `center()` on first launch when there's no saved frame. The initial `contentRect` is set to the real content size (480×280) so the first-launch centered window is correct.
- **`WindowCoordinator.installMainWindowContent`** — set the hosting view's `sizingOptions` to `[.minSize, .maxSize]`, dropping `.intrinsicContentSize`. This keeps the SwiftUI min/max as the window's resize limits but stops the hosting view from forcing the window back to its ideal size on install.

## Notes

- Native macOS app — can't be compiled/run in the CI-less Linux session this was authored in. The change uses standard AppKit/SwiftUI APIs available on the project's macOS 14 deployment target (`setFrameUsingName`, `setFrameAutosaveName`, `NSHostingView.sizingOptions`).
- Resize limits are unchanged (still 480–650 × 280–400). The URL-scheme screenshot resize (`handleWindowResize`) is unaffected — max-size behavior matches the previous default.

## Testing

Manual verification on macOS recommended: resize and move the window, quit, reopen — the window should return to the same size and position; a fresh install (no saved frame) should open centered at 480×280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1nn9QbVq15UqtmcMN7McJ)_