### PR TITLE
ci: run Claude Code workflows on macOS so they can build Pika

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,9 +23,12 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: ubuntu-latest
+    # macOS so Claude can build/test the app (AppKit/SwiftUI) during a review;
+    # matches tests.yml. GitHub-hosted runners are free on public repos.
+    runs-on: macos-15
     # Fail loudly instead of hanging up to GitHub's 6h default if a run wedges.
-    timeout-minutes: 20
+    # A touch higher than Linux to allow for Xcode build time during review.
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -37,6 +40,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Run Claude Code Review
         id: claude-review

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,9 @@ jobs:
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
       )
-    runs-on: ubuntu-latest
+    # macOS so Claude can build/test the app (AppKit/SwiftUI) during a review;
+    # matches tests.yml. GitHub-hosted runners are free on public repos.
+    runs-on: macos-15
     permissions:
       contents: write
       pull-requests: write
@@ -42,6 +44,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Run Claude Code
         id: claude


### PR DESCRIPTION
The `@claude` responder (`claude.yml`) and the auto PR review (`claude-code-review.yml`) ran on `ubuntu-latest`. Because Pika is a macOS AppKit/SwiftUI app, Claude couldn't run `xcodebuild`/the test suite while reviewing — it flagged this itself in [#226's review](https://github.com/superhighfives/pika/pull/226#issuecomment-4994457388) ("this runner is Linux-only … I wasn't able to run `xcodebuild`").

## Changes
- Both Claude workflows → `runs-on: macos-15` with a `Select Xcode` step (Xcode 16.3), matching `tests.yml`.
- Bumped the auto-review `timeout-minutes` 20 → 30 to allow for Xcode build time.

## Not changed
- `tests.yml` — already `macos-15` (it's the one that actually builds + tests Pika).
- `update-color-names.yml` — stays on Linux; it only `curl`s a JSON list and opens a PR, nothing to build.

GitHub-hosted runners are free on public repos, so there's no cost trade-off to moving these to macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)