### PR TITLE
Window shadow control and adaptive window sizing

### DIFF
--- a/Pika/Assets/de.lproj/Localizable.strings
+++ b/Pika/Assets/de.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "Vordergrund und Hintergrund auswählen";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/de.lproj/Localizable.strings
+++ b/Pika/Assets/de.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/en.lproj/Localizable.strings
+++ b/Pika/Assets/en.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "preferences.window.title" = "Window Settings";
 
 /* Window shadow: always on */
-"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.always" = "Show shadow";
 
 /* Window shadow: hidden while picking */
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
 
 /* Window shadow: never */
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand the window to fit hidden elements */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/en.lproj/Localizable.strings
+++ b/Pika/Assets/en.lproj/Localizable.strings
@@ -82,6 +82,24 @@
 /* Pick a contrasting background color after the foreground */
 "preferences.pick.contrasting" = "Pick contrasting color after foreground";
 
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";
+
+/* Window shadow: always on */
+"preferences.shadow.options.always" = "Shadow";
+
+/* Window shadow: hidden while picking */
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+
+/* Window shadow: never */
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand the window to fit hidden elements */
+"content.expandToFit" = "Expand to fit";
+
 /* General Settings */
 "preferences.general.title" = "General Settings";
 
@@ -161,13 +179,13 @@
 "color.standard.both" = "Both";
 
 /* Contrast ratio */
-"color.ratio" = "Contrast Ratio";
+"color.ratio" = "Contrast";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Contrast Value (Lc)";
+"color.lc" = "Contrast (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value.";
@@ -215,7 +233,7 @@
 "color.apca.title" = "Title";
 
 /* Body Text */
-"color.apca.body" = "Body Text";
+"color.apca.body" = "Body";
 
 /* Pass */
 "color.wcag.pass" = "Pass";

--- a/Pika/Assets/es.lproj/Localizable.strings
+++ b/Pika/Assets/es.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "Seleccionar primer plano y segundo plano";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/es.lproj/Localizable.strings
+++ b/Pika/Assets/es.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/fr.lproj/Localizable.strings
+++ b/Pika/Assets/fr.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "Sélectionner premier plan et arrière-plan";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/fr.lproj/Localizable.strings
+++ b/Pika/Assets/fr.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/hr.lproj/Localizable.strings
+++ b/Pika/Assets/hr.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/hr.lproj/Localizable.strings
+++ b/Pika/Assets/hr.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "Odaberi prednju i pozadinsku boju";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/ja.lproj/Localizable.strings
+++ b/Pika/Assets/ja.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "前景色と背景色をピック";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/ja.lproj/Localizable.strings
+++ b/Pika/Assets/ja.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/pl.lproj/Localizable.strings
+++ b/Pika/Assets/pl.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "Wybierz pierwszy plan i tło";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/pl.lproj/Localizable.strings
+++ b/Pika/Assets/pl.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hans.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "选择前景色和背景色";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hans.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/zh-Hant.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hant.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "選擇前景色和背景色";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/zh-Hant.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hant.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Constants/Constants.swift
+++ b/Pika/Constants/Constants.swift
@@ -68,6 +68,7 @@ enum PikaConstants {
     static let ncSavePalette = "savePalette"
     static let ncExportPalette = "exportPalette"
     static let ncSystemColorChanged = "systemColorChanged"
+    static let ncExpandToFit = "expandToFit"
 
     // Disabled formats for SwiftUI copy format
     static let disabledFormats: [ColorFormat] = [.hex, .hsl, .opengl, .lab, .oklch]
@@ -104,6 +105,7 @@ extension Notification.Name {
     static let savePalette = Notification.Name(PikaConstants.ncSavePalette)
     static let exportPalette = Notification.Name(PikaConstants.ncExportPalette)
     static let systemColorChanged = Notification.Name(PikaConstants.ncSystemColorChanged)
+    static let expandToFit = Notification.Name(PikaConstants.ncExpandToFit)
 }
 
 enum PikaText {
@@ -275,6 +277,18 @@ enum PikaText {
     static let textPickContrasting = NSLocalizedString(
         "preferences.pick.contrasting",
         comment: "Pick a contrasting background color after the foreground"
+    )
+    static let textWindowShadow = NSLocalizedString(
+        "preferences.shadow.description",
+        comment: "Window shadow"
+    )
+    static let textWindowSettingsTitle = NSLocalizedString(
+        "preferences.window.title",
+        comment: "Window Settings"
+    )
+    static let textExpandToFit = NSLocalizedString(
+        "content.expandToFit",
+        comment: "Expand the window to fit hidden elements"
     )
     static let textIconDescription = NSLocalizedString(
         "preferences.icon.description",

--- a/Pika/Constants/Defaults.swift
+++ b/Pika/Constants/Defaults.swift
@@ -46,6 +46,20 @@ enum ContrastStandard: String, Codable, CaseIterable {
     }
 }
 
+enum WindowShadow: String, Codable, CaseIterable {
+    case always = "preferences.shadow.options.always"
+    case hiddenWhilePicking = "preferences.shadow.options.hiddenWhilePicking"
+    case never = "preferences.shadow.options.never"
+
+    func localizedString() -> String {
+        NSLocalizedString(rawValue, comment: "Window Shadow")
+    }
+
+    /// The window's resting shadow state. `.hiddenWhilePicking` keeps the shadow at
+    /// rest and only drops it during an active pick (handled by the picker).
+    var showsShadowAtRest: Bool { self != .never }
+}
+
 enum AppMode: String, Codable, CaseIterable {
     case menubar = "preferences.app.mode.menubar"
     case regular = "preferences.app.mode.regular"
@@ -71,6 +85,7 @@ extension Defaults.Keys {
     static let colorFormat = Key<ColorFormat>("colorFormat", default: .hex)
     static let viewedSplash = Key<Bool>("viewedSplash", default: false)
     static let hidePikaWhilePicking = Key<Bool>("hidePikaWhilePicking", default: false)
+    static let windowShadow = Key<WindowShadow>("windowShadow", default: .always)
     static let pickContrastingColor = Key<Bool>("pickContrastingColor", default: false)
     static let copyColorOnPick = Key<Bool>("copyColorOnPick", default: false)
     static let hideMenuBarIcon = Key<Bool>("hideMenuBarIcon", default: false)

--- a/Pika/Services/Eyedroppers.swift
+++ b/Pika/Services/Eyedroppers.swift
@@ -453,12 +453,25 @@ class Eyedropper: ObservableObject {
             NSApp.sendAction(#selector(AppDelegate.hidePika), to: nil, from: nil)
         }
 
+        // Drop the window's shadow while the sampler is up so it can't tint pixels
+        // picked near the window edge. Restored when the pick completes — except when
+        // handing off to a chained background pick, which keeps it suppressed.
+        let suppressShadow = Defaults[.windowShadow] == .hiddenWhilePicking
+        let windowCoordinator = (NSApp.delegate as? AppDelegate)?.windowCoordinator
+        if suppressShadow {
+            windowCoordinator?.setPickingShadowSuppressed(true)
+        }
+
         DispatchQueue.main.asyncAfter(deadline: .now()) {
             if Defaults[.appMode].usesPopover {
                 NSApp.activate(ignoringOtherApps: true)
             }
             let sampler = NSColorSampler()
             sampler.show { selectedColor in
+
+                // Keep the shadow suppressed only when handing off to a chained
+                // background pick; every terminal path restores it below.
+                var handedOff = false
 
                 if let selectedColor = selectedColor {
                     let normalizedColor = selectedColor.usingColorSpace(.sRGB) ?? selectedColor
@@ -486,6 +499,7 @@ class Eyedropper: ObservableObject {
                         // background is also picked (or the chained pick is cancelled).
                         let background = appDelegate.eyedroppers.background
                         background.pendingChainCommit = true
+                        handedOff = true
                         // Don't bounce Pika back into view between picks: forward the
                         // forceShow intent to the background pick instead.
                         if self.forceShow {
@@ -528,6 +542,10 @@ class Eyedropper: ObservableObject {
                     if !Defaults[.appMode].usesPopover {
                         NSApp.sendAction(#selector(AppDelegate.showPika), to: nil, from: nil)
                     }
+                }
+
+                if suppressShadow, !handedOff {
+                    windowCoordinator?.setPickingShadowSuppressed(false)
                 }
 
                 let panel = NSColorPanel.shared

--- a/Pika/Services/PikaWindow.swift
+++ b/Pika/Services/PikaWindow.swift
@@ -26,15 +26,12 @@ class PikaWindow {
         // The window's drop shadow can bleed onto pixels beneath its edge and skew
         // colour readings taken nearby. Honour the user's shadow preference; the
         // `.hiddenWhilePicking` case keeps the resting shadow and is dropped mid-pick
-        // by `Eyedropper.start`.
+        // by `Eyedropper.start`. Setting *changes* (and the companion border shown while
+        // shadowless) are handled in `WindowCoordinator`.
         window.hasShadow = Defaults[.windowShadow].showsShadowAtRest
 
         Defaults.observe(.appFloating) { change in
             window.level = change.newValue == true ? .floating : .normal
-        }.tieToLifetime(of: self)
-
-        Defaults.observe(.windowShadow) { change in
-            window.hasShadow = change.newValue.showsShadowAtRest
         }.tieToLifetime(of: self)
 
         // Set up toolbar

--- a/Pika/Services/PikaWindow.swift
+++ b/Pika/Services/PikaWindow.swift
@@ -23,8 +23,18 @@ class PikaWindow {
         window.standardWindowButton(NSWindow.ButtonType.zoomButton)!.isEnabled = false
         window.titlebarAppearsTransparent = true
 
+        // The window's drop shadow can bleed onto pixels beneath its edge and skew
+        // colour readings taken nearby. Honour the user's shadow preference; the
+        // `.hiddenWhilePicking` case keeps the resting shadow and is dropped mid-pick
+        // by `Eyedropper.start`.
+        window.hasShadow = Defaults[.windowShadow].showsShadowAtRest
+
         Defaults.observe(.appFloating) { change in
             window.level = change.newValue == true ? .floating : .normal
+        }.tieToLifetime(of: self)
+
+        Defaults.observe(.windowShadow) { change in
+            window.hasShadow = change.newValue.showsShadowAtRest
         }.tieToLifetime(of: self)
 
         // Set up toolbar

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -29,6 +29,40 @@ class WindowCoordinator: NSObject {
         // silently disabling frame autosave. Assign the name on the controller so it
         // sticks and AppKit persists size/position on move and resize.
         pikaTouchBarController.windowFrameAutosaveName = PikaWindow.primaryWindowAutosaveName
+
+        // The adaptive layout posts this when the user taps "expand to fit"; grow the
+        // window just enough to reveal the elements it's currently suppressing.
+        notificationCenter.addObserver(
+            forName: .expandToFit, object: nil, queue: .main
+        ) { [weak self] note in
+            guard let self, let size = (note.object as? NSValue)?.sizeValue else { return }
+            self.resizeMainWindow(toFitContent: size)
+        }
+    }
+
+    /// Grows the main window so its content area is at least `contentSize`, keeping the
+    /// top-left corner fixed (the natural anchor for a window being enlarged). Clamped to
+    /// the window's own min/max so it never fights the resize limits.
+    private func resizeMainWindow(toFitContent contentSize: NSSize) {
+        // `sizingOptions` mirrors the SwiftUI frame's min/max onto the window's content
+        // size limits, so clamp the request to those before converting to a window frame.
+        let minContent = pikaWindow.contentMinSize
+        let maxContent = pikaWindow.contentMaxSize
+        let targetContentWidth = min(max(contentSize.width, minContent.width), maxContent.width)
+        let targetContentHeight = min(max(contentSize.height, minContent.height), maxContent.height)
+
+        // Chrome (titlebar + toolbar) sits outside the SwiftUI content, so add the live
+        // inset to turn a content height into a window height. Width has no side chrome.
+        let chromeHeight = pikaWindow.frame.height - pikaWindow.contentLayoutRect.height
+
+        var frame = pikaWindow.frame
+        // Only ever grow — never shrink an axis that already has room.
+        let newWidth = max(frame.width, targetContentWidth)
+        let newHeight = max(frame.height, targetContentHeight + chromeHeight)
+        let top = frame.maxY
+        frame.size = NSSize(width: newWidth, height: newHeight)
+        frame.origin.y = top - newHeight
+        pikaWindow.setFrame(frame, display: true, animate: true)
     }
 
     /// Mounts the SwiftUI content tree on the main window. Call only when the active mode
@@ -38,10 +72,13 @@ class WindowCoordinator: NSObject {
         guard let eyedroppers = eyedroppers else { return }
         let contentView = ContentView()
             .environmentObject(eyedroppers)
-            .frame(minWidth: 480,
+            // Floor is well below the "everything visible" height: ContentView sheds
+            // elements adaptively as it shrinks (see PikaAdaptiveHeight), so the window
+            // can get compact again. Ideal stays at the comfortable first-launch size.
+            .frame(minWidth: 360,
                    idealWidth: 480,
                    maxWidth: 650,
-                   minHeight: 280,
+                   minHeight: 160,
                    idealHeight: 280,
                    maxHeight: 400,
                    alignment: .center)
@@ -56,6 +93,14 @@ class WindowCoordinator: NSObject {
 
     func removeMainWindowContent() {
         pikaWindow.contentView = nil
+    }
+
+    /// Drops or restores the main window's drop shadow around an active pick.
+    /// Only takes effect for `.hiddenWhilePicking`; the other modes keep their
+    /// resting shadow, which is owned by `PikaWindow`.
+    func setPickingShadowSuppressed(_ suppressed: Bool) {
+        guard Defaults[.windowShadow] == .hiddenWhilePicking else { return }
+        pikaWindow.hasShadow = !suppressed
     }
 
     func startMainWindow() {

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -8,6 +8,10 @@ class WindowCoordinator: NSObject {
     weak var eyedroppers: Eyedroppers?
 
     private(set) var pikaWindow: NSWindow!
+    private var borderWindow: NSWindow?
+    /// The border window extends this far beyond the main window frame so its outline can
+    /// be drawn out on the window's visible glass edge (which sits just past the frame).
+    private let borderPad: CGFloat = 6.0
     private var splashWindow: NSWindow!
     private var aboutWindow: NSWindow?
     private var helpWindow: NSWindow?
@@ -38,6 +42,82 @@ class WindowCoordinator: NSObject {
             guard let self, let size = (note.object as? NSValue)?.sizeValue else { return }
             self.resizeMainWindow(toFitContent: size)
         }
+
+        // Apply the shadow setting and show/hide the companion border to match.
+        Defaults.observe(.windowShadow) { [weak self] change in
+            guard let self else { return }
+            self.pikaWindow.hasShadow = change.newValue.showsShadowAtRest
+            self.updateShadowBorder()
+        }.tieToLifetime(of: self)
+
+        // Keep the border aligned to the main window and re-attached whenever it shows.
+        for name in [NSWindow.didResizeNotification, NSWindow.didMoveNotification] {
+            notificationCenter.addObserver(forName: name, object: pikaWindow, queue: .main) {
+                [weak self] _ in
+                guard let self, let border = self.borderWindow, border.parent != nil else { return }
+                border.setFrame(self.borderFrame(), display: true)
+            }
+        }
+        notificationCenter.addObserver(
+            forName: NSWindow.didBecomeKeyNotification, object: pikaWindow, queue: .main
+        ) { [weak self] _ in
+            self?.updateShadowBorder()
+        }
+
+        updateShadowBorder()
+    }
+
+    /// The main window can lose its drop shadow (either via the setting or while picking),
+    /// which lets it blend into the desktop. A `.borderless`, click-through child window
+    /// laid exactly over it draws a hairline outline (matching the in-window dividers) so
+    /// the edge stays defined. Shown only while the window is shadowless.
+    func updateShadowBorder() {
+        guard pikaWindow != nil else { return }
+
+        guard !pikaWindow.hasShadow else {
+            if let border = borderWindow {
+                pikaWindow.removeChildWindow(border)
+                border.orderOut(nil)
+            }
+            return
+        }
+
+        let border = borderWindow ?? makeBorderWindow()
+        borderWindow = border
+        border.setFrame(borderFrame(), display: true)
+        if border.parent == nil {
+            pikaWindow.addChildWindow(border, ordered: .above)
+        }
+        if let borderView = border.contentView as? ShadowBorderView {
+            // Push the stroke ~1.5pt beyond the main frame edge so it lands on the visible
+            // glass edge, and match the window's rounded-corner radius.
+            borderView.strokeInset = borderPad
+            borderView.cornerRadius = 20
+        }
+        border.orderFront(nil)
+        border.contentView?.needsDisplay = true
+    }
+
+    /// The border window frame — the main window's frame grown by `borderPad` on all sides.
+    private func borderFrame() -> NSRect {
+        pikaWindow.frame.insetBy(dx: -borderPad, dy: -borderPad)
+    }
+
+    private func makeBorderWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: borderFrame(),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = false
+        window.ignoresMouseEvents = true
+        window.isReleasedWhenClosed = false
+        window.level = pikaWindow.level
+        window.contentView = ShadowBorderView()
+        return window
     }
 
     /// Grows the main window so its content area is at least `contentSize`, keeping the
@@ -75,13 +155,15 @@ class WindowCoordinator: NSObject {
             // Floor is well below the "everything visible" height: ContentView sheds
             // elements adaptively as it shrinks (see PikaAdaptiveHeight), so the window
             // can get compact again. Ideal stays at the comfortable first-launch size.
-            .frame(minWidth: 360,
-                   idealWidth: 480,
-                   maxWidth: 650,
-                   minHeight: 160,
-                   idealHeight: 280,
-                   maxHeight: 400,
-                   alignment: .center)
+            .frame(
+                minWidth: 360,
+                idealWidth: 480,
+                maxWidth: 650,
+                minHeight: 160,
+                idealHeight: 280,
+                maxHeight: 400,
+                alignment: .center
+            )
         let hostingView = NSHostingView(rootView: contentView)
         // Apply the SwiftUI min/max as the window's resize limits, but omit
         // `.intrinsicContentSize` so the hosting view doesn't snap the window back
@@ -101,17 +183,20 @@ class WindowCoordinator: NSObject {
     func setPickingShadowSuppressed(_ suppressed: Bool) {
         guard Defaults[.windowShadow] == .hiddenWhilePicking else { return }
         pikaWindow.hasShadow = !suppressed
+        updateShadowBorder()
     }
 
     func startMainWindow() {
         if !pikaWindow.isVisible {
             pikaWindow.fadeIn(nil)
         }
+        updateShadowBorder()
         Defaults[.viewedSplash] = true
     }
 
     func showMainWindow() {
         pikaWindow.makeKeyAndOrderFront(nil)
+        updateShadowBorder()
     }
 
     func hideMainWindow() {
@@ -119,7 +204,9 @@ class WindowCoordinator: NSObject {
     }
 
     func closeSplashWindow() {
-        splashWindow.fadeOut(sender: nil, duration: 0.25, closeSelector: .close, completionHandler: startMainWindow)
+        splashWindow.fadeOut(
+            sender: nil, duration: 0.25, closeSelector: .close, completionHandler: startMainWindow
+        )
     }
 
     func togglePopover() {
@@ -137,6 +224,7 @@ class WindowCoordinator: NSObject {
         } else {
             pikaWindow.fadeIn(sender: nil, duration: 0.2)
         }
+        updateShadowBorder()
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -216,5 +304,37 @@ class WindowCoordinator: NSObject {
         splashTouchBarController = SplashTouchBarController(window: splashWindow)
         splashWindow.contentView = NSHostingView(rootView: SplashView().edgesIgnoringSafeArea(.all))
         splashWindow.fadeIn(nil)
+    }
+}
+
+/// Draws the main window's hairline outline for the companion border window. Strokes a
+/// rounded rect matching the window's corner radius, in a colour that adapts to the
+/// current appearance (matching `AdaptiveDivider`).
+private final class ShadowBorderView: NSView {
+    /// Corner radius of the window's visible edge.
+    var cornerRadius: CGFloat = 16.0 { didSet { needsDisplay = true } }
+    /// How far the stroke sits inside the view bounds. The view is larger than the main
+    /// window frame (see `WindowCoordinator.borderPad`); reducing this pushes the outline
+    /// outward to sit on the window's visible glass edge rather than its frame.
+    var strokeInset: CGFloat = 4.0 { didSet { needsDisplay = true } }
+
+    override var allowsVibrancy: Bool { false }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsDisplay = true
+    }
+
+    override func draw(_: NSRect) {
+        let isDark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        let color =
+            isDark
+                ? NSColor.white.withAlphaComponent(0.14)
+                : NSColor.black.withAlphaComponent(0.24)
+        let rect = bounds.insetBy(dx: strokeInset, dy: strokeInset)
+        let path = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
+        path.lineWidth = 1.0
+        color.setStroke()
+        path.stroke()
     }
 }

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -50,6 +50,13 @@ class WindowCoordinator: NSObject {
             self.updateShadowBorder()
         }.tieToLifetime(of: self)
 
+        // Keep the border on the same window level as the main window (which PikaWindow
+        // moves between .floating/.normal), so toggling "float on top" doesn't leave the
+        // border stranded on a stale level.
+        Defaults.observe(.appFloating) { [weak self] change in
+            self?.borderWindow?.level = change.newValue == true ? .floating : .normal
+        }.tieToLifetime(of: self)
+
         // Keep the border aligned to the main window and re-attached whenever it shows.
         for name in [NSWindow.didResizeNotification, NSWindow.didMoveNotification] {
             notificationCenter.addObserver(forName: name, object: pikaWindow, queue: .main) {
@@ -88,9 +95,10 @@ class WindowCoordinator: NSObject {
         if border.parent == nil {
             pikaWindow.addChildWindow(border, ordered: .above)
         }
+        border.level = pikaWindow.level
         if let borderView = border.contentView as? ShadowBorderView {
-            // Push the stroke ~1.5pt beyond the main frame edge so it lands on the visible
-            // glass edge, and match the window's rounded-corner radius.
+            // Sit the stroke on the main window's frame edge (which lines up with the
+            // visible glass edge), and match the window's rounded-corner radius.
             borderView.strokeInset = borderPad
             borderView.cornerRadius = 20
         }

--- a/Pika/Views/ColorHistoryDrawer.swift
+++ b/Pika/Views/ColorHistoryDrawer.swift
@@ -255,6 +255,7 @@ struct ColorHistoryDrawer: View {
     @ObservedObject var background: Eyedropper
     @Default(.palettes) var palettes
     @Default(.activePaletteIndex) var activePaletteIndex
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var isShowingClearConfirm = false
     @State private var slideDirection: VerticalDirection = .down
@@ -273,10 +274,10 @@ struct ColorHistoryDrawer: View {
     }
 
     var body: some View {
-        Divider()
+        AdaptiveDivider()
         VStack(spacing: 0) {
             PaletteTabBar(slideDirection: $slideDirection)
-            Divider()
+            AdaptiveDivider()
             HStack(spacing: 0) {
                 ZStack {
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -316,7 +317,7 @@ struct ColorHistoryDrawer: View {
                 }
 
                 HStack(spacing: 0) {
-                    Divider()
+                    AdaptiveDivider(axis: .vertical)
 
                     if isAutoHistory {
                         Button(action: { isShowingClearConfirm = true }) {
@@ -350,11 +351,10 @@ struct ColorHistoryDrawer: View {
         }
         .background(
             ZStack {
-                VisualEffect(
-                    material: NSVisualEffectView.Material.underWindowBackground,
-                    blendingMode: NSVisualEffectView.BlendingMode.behindWindow
-                )
-                Color.black.opacity(0.2)
+                AdaptivePanelBackground()
+                // Barely-there tint so the drawer reads as almost the same surface as the
+                // contrast footer — just a whisper of separation.
+                Color.black.opacity(colorScheme == .dark ? 0.06 : 0.02)
             }
         )
         .alert(PikaText.textHistoryClear, isPresented: $isShowingClearConfirm) {

--- a/Pika/Views/ColorPickers.swift
+++ b/Pika/Views/ColorPickers.swift
@@ -7,10 +7,9 @@ struct ColorPickers: View {
         let eyedropperArray: [Eyedropper] = [eyedroppers.foreground, eyedroppers.background]
 
         HStack(spacing: 0.0) {
-            ForEach(Array(eyedropperArray.enumerated()), id: \.element.type) { index, eyedropper in
-                if index > 0 {
-                    Divider()
-                }
+            ForEach(Array(eyedropperArray.enumerated()), id: \.element.type) { _, eyedropper in
+                // No divider between the two swatches — the colours meet directly, and the
+                // horizontal section dividers do the framing.
                 EyedropperItem(eyedropper: eyedropper)
             }
         }

--- a/Pika/Views/ComplianceToggle.swift
+++ b/Pika/Views/ComplianceToggle.swift
@@ -12,8 +12,12 @@ struct ComplianceToggle: View {
         HStack(alignment: .center, spacing: 2.0) {
             IconImage(name: isCompliant ? "checkmark.circle.fill" : "xmark.circle", resizable: true)
                 .frame(width: size == .small ? 13.0 : 14.0, height: size == .small ? 13.0 : 14.0)
+                .layoutPriority(1)
+            // Truncate (e.g. "Bo…") when the footer is too narrow to fit the full label,
+            // rather than clipping. Full size otherwise.
             Text(title)
-                .fixedSize()
+                .lineLimit(1)
+                .truncationMode(.tail)
 
             if combined {
                 if large {
@@ -43,7 +47,6 @@ struct ComplianceToggle: View {
         .foregroundColor(isCompliant ? .primary
             : .secondary)
         .help(tooltip)
-        .fixedSize()
     }
 }
 

--- a/Pika/Views/ContentView.swift
+++ b/Pika/Views/ContentView.swift
@@ -5,8 +5,10 @@ import UniformTypeIdentifiers
 
 /// Height thresholds (in points of available window content height) below which each
 /// element is shed, so the window can shrink far smaller than the sum of everything.
-/// Ordered largest-first to match the shed order: palettes drop first, type labels last.
-/// These are the tuning knobs for the adaptive layout.
+/// Ordered largest-first to match the shed order: palettes drop first, then contrast,
+/// preview, and colour names. Type labels are the last to go, but they hide only via the
+/// preview-pill overlap — the window floor (160) sits above any useful height threshold
+/// for them. These are the tuning knobs for the adaptive layout.
 enum PikaAdaptiveHeight {
     static let floor: CGFloat = 160 // bare minimum content height (matches window frame min ≈ 200pt window)
     static let expandCornerBelow: CGFloat = 200 // below this content height (~240pt window) the button tucks top-right
@@ -14,7 +16,6 @@ enum PikaAdaptiveHeight {
     static let contrast: CGFloat = 250 // compliance footer (~50pt)
     static let preview: CGFloat = 200 // preview pill
     static let colorNames: CGFloat = 175 // CSS colour name under each value
-    static let typeLabels: CGFloat = 150 // "Foreground"/"Background" labels
 }
 
 /// Width thresholds below which horizontally-laid-out elements are shed rather than left
@@ -181,7 +182,9 @@ struct ContentView: View {
             }
             .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
             .environment(\.pikaAdaptiveVisibility, PikaAdaptiveVisibility(
-                showsTypeLabels: height >= PikaAdaptiveHeight.typeLabels && !previewVisible,
+                // Type labels sit behind the preview pill, so they hide only when it shows
+                // — the window floor keeps height above any threshold that would drop them.
+                showsTypeLabels: !previewVisible,
                 showsColorNames: height >= PikaAdaptiveHeight.colorNames
             ))
             // Continuous hover is stable when the button appears under the cursor —

--- a/Pika/Views/ContentView.swift
+++ b/Pika/Views/ContentView.swift
@@ -3,6 +3,51 @@ import Defaults
 import SwiftUI
 import UniformTypeIdentifiers
 
+/// Height thresholds (in points of available window content height) below which each
+/// element is shed, so the window can shrink far smaller than the sum of everything.
+/// Ordered largest-first to match the shed order: palettes drop first, type labels last.
+/// These are the tuning knobs for the adaptive layout.
+enum PikaAdaptiveHeight {
+    static let floor: CGFloat = 160 // bare minimum content height (matches window frame min ≈ 200pt window)
+    static let expandCornerBelow: CGFloat = 200 // below this content height (~240pt window) the button tucks top-right
+    static let palettes: CGFloat = 300 // history drawer (~74pt)
+    static let contrast: CGFloat = 250 // compliance footer (~50pt)
+    static let preview: CGFloat = 200 // preview pill
+    static let colorNames: CGFloat = 175 // CSS colour name under each value
+    static let typeLabels: CGFloat = 150 // "Foreground"/"Background" labels
+}
+
+/// Width thresholds below which horizontally-laid-out elements are shed rather than left
+/// to clip past the window edge. The footer's contrast panels are the widest content.
+enum PikaAdaptiveWidth {
+    static let base: CGFloat = 360 // bare minimum content width (matches window frame min)
+    // Footer (with its shortened labels) and the palette drawer share one hide width so
+    // they appear/disappear together — different values read as a bug.
+    static let palettes: CGFloat = 460
+    static let contrast: CGFloat = 460
+    static let preview: CGFloat = 420 // preview pill
+}
+
+/// Size-driven visibility for elements inside the eyedropper rows, threaded down to
+/// the deeply-nested `EyedropperButton` via the environment. `true` means "there is
+/// room" — it's ANDed with the user's own preference at the point of use, so a saved
+/// setting is never mutated (suppress-but-remember).
+struct PikaAdaptiveVisibility: Equatable {
+    var showsTypeLabels: Bool = true
+    var showsColorNames: Bool = true
+}
+
+private struct PikaAdaptiveVisibilityKey: EnvironmentKey {
+    static let defaultValue = PikaAdaptiveVisibility()
+}
+
+extension EnvironmentValues {
+    var pikaAdaptiveVisibility: PikaAdaptiveVisibility {
+        get { self[PikaAdaptiveVisibilityKey.self] }
+        set { self[PikaAdaptiveVisibilityKey.self] = newValue }
+    }
+}
+
 struct ContentView: View {
     @EnvironmentObject var eyedroppers: Eyedroppers
 
@@ -20,59 +65,137 @@ struct ContentView: View {
     @State var swapVisible: Bool = false
     @State private var swapTimerSubscription: Cancellable?
     @State private var swapTimer = Timer.publish(every: 0.25, on: .main, in: .common)
+    @State private var isHovering: Bool = false
+
+    /// Content size that comfortably shows every element the user currently has enabled —
+    /// the target for the "expand to fit" control. Takes the largest width/height each
+    /// enabled element needs, plus a small margin so it lands just past each threshold.
+    private func expandTargetSize() -> CGSize {
+        let margin: CGFloat = 8
+        var width = PikaAdaptiveWidth.base
+        var height = PikaAdaptiveHeight.floor
+        if showColorPreview {
+            width = max(width, PikaAdaptiveWidth.preview)
+            height = max(height, PikaAdaptiveHeight.preview)
+        }
+        if showCompliance {
+            width = max(width, PikaAdaptiveWidth.contrast)
+            height = max(height, PikaAdaptiveHeight.contrast)
+        }
+        if historyDrawerVisible {
+            width = max(width, PikaAdaptiveWidth.palettes)
+            height = max(height, PikaAdaptiveHeight.palettes)
+        }
+        return CGSize(width: width + margin, height: height + margin)
+    }
 
     var body: some View {
-        VStack(alignment: .trailing, spacing: 0) {
-            Divider()
-            ColorPickers()
-                .onHover { hover in
-                    guard hover else { return }
-                    swapVisible = true
-                    swapTimerSubscription?.cancel()
-                    swapTimerSubscription = nil
-                }
-                .onReceive(swapTimer) { _ in
-                    swapVisible = false
-                    swapTimerSubscription?.cancel()
-                    swapTimerSubscription = nil
-                }
-                .overlay(
-                    SwapPreviewButton(
-                        foreground: eyedroppers.foreground,
-                        background: eyedroppers.background,
-                        showPreview: showColorPreview,
-                        isVisible: swapVisible,
-                        onSwap: {
-                            NSApp.sendAction(#selector(AppDelegate.triggerSwap), to: nil, from: nil)
-                        }
-                    )
-                    .onReceive(NotificationCenter.default.publisher(for: .triggerSwap)) { _ in
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            eyedroppers.swap()
-                        }
-                    }
-                    .focusable(false)
-                    .padding(.horizontal, 16.0)
-                    .padding(.top, appMode.usesPopover ? 42.0 : 16.0)
-                    .frame(maxHeight: .infinity, alignment: .top)
-                )
-                .onHover { hover in
-                    guard !hover, swapTimerSubscription == nil else {
-                        return
-                    }
-                    swapTimer = Timer.publish(every: 0.25, on: .main, in: .common)
-                    swapTimerSubscription = swapTimer.connect()
-                }
+        GeometryReader { geo in
+            let height = geo.size.height
+            let width = geo.size.width
+            // Room-for flags: an element needs both enough height AND enough width, or it
+            // clips. ANDed with user preferences below so the saved toggles survive
+            // resizing (suppress-but-remember).
+            let allowPreview = height >= PikaAdaptiveHeight.preview && width >= PikaAdaptiveWidth.preview
+            let allowContrast = height >= PikaAdaptiveHeight.contrast && width >= PikaAdaptiveWidth.contrast
+            let allowPalettes = height >= PikaAdaptiveHeight.palettes && width >= PikaAdaptiveWidth.palettes
+            // The preview pill overlaps the type labels, so labels only show when the
+            // pill is effectively hidden.
+            let previewVisible = showColorPreview && allowPreview
 
-            if showCompliance {
+            // An enabled element we're hiding purely for space. When any exist, offer to
+            // grow the window back to a size that fits everything the user has turned on.
+            let suppressed = (showColorPreview && !allowPreview)
+                || (showCompliance && !allowContrast)
+                || (historyDrawerVisible && !allowPalettes)
+            // Centre the affordance normally, but at very short heights tuck it into the
+            // top-right corner so it doesn't sit on top of the colour values.
+            let expandAlignment: Alignment = height < PikaAdaptiveHeight.expandCornerBelow ? .topTrailing : .center
+
+            VStack(alignment: .trailing, spacing: 0) {
                 Divider()
-                Footer(foreground: eyedroppers.foreground, background: eyedroppers.background)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                ColorPickers()
+                    .onHover { hover in
+                        guard hover else { return }
+                        swapVisible = true
+                        swapTimerSubscription?.cancel()
+                        swapTimerSubscription = nil
+                    }
+                    .onReceive(swapTimer) { _ in
+                        swapVisible = false
+                        swapTimerSubscription?.cancel()
+                        swapTimerSubscription = nil
+                    }
+                    .overlay(
+                        SwapPreviewButton(
+                            foreground: eyedroppers.foreground,
+                            background: eyedroppers.background,
+                            showPreview: previewVisible,
+                            isVisible: swapVisible,
+                            onSwap: {
+                                NSApp.sendAction(#selector(AppDelegate.triggerSwap), to: nil, from: nil)
+                            }
+                        )
+                        .onReceive(NotificationCenter.default.publisher(for: .triggerSwap)) { _ in
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                eyedroppers.swap()
+                            }
+                        }
+                        .focusable(false)
+                        .padding(.horizontal, 16.0)
+                        .padding(.top, appMode.usesPopover ? 42.0 : 16.0)
+                        .frame(maxHeight: .infinity, alignment: .top)
+                    )
+                    // Expand-to-fit sits over the colour tiles (not the whole app), so it
+                    // centres on the swatches rather than drifting down over the footer.
+                    .overlay(alignment: expandAlignment) {
+                        if suppressed, isHovering {
+                            ExpandToFitButton {
+                                NotificationCenter.default.post(
+                                    name: .expandToFit,
+                                    object: NSValue(size: expandTargetSize())
+                                )
+                            }
+                            .padding(expandAlignment == .topTrailing ? 8 : 0)
+                            .transition(.scale(scale: 0.9).combined(with: .opacity))
+                        }
+                    }
+                    .onHover { hover in
+                        guard !hover, swapTimerSubscription == nil else {
+                            return
+                        }
+                        swapTimer = Timer.publish(every: 0.25, on: .main, in: .common)
+                        swapTimerSubscription = swapTimer.connect()
+                    }
+
+                if showCompliance, allowContrast {
+                    AdaptiveDivider()
+                    Footer(foreground: eyedroppers.foreground, background: eyedroppers.background)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+                if historyDrawerVisible, allowPalettes {
+                    ColorHistoryDrawer(foreground: eyedroppers.foreground, background: eyedroppers.background)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
-            if historyDrawerVisible {
-                ColorHistoryDrawer(foreground: eyedroppers.foreground, background: eyedroppers.background)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
+            .environment(\.pikaAdaptiveVisibility, PikaAdaptiveVisibility(
+                showsTypeLabels: height >= PikaAdaptiveHeight.typeLabels && !previewVisible,
+                showsColorNames: height >= PikaAdaptiveHeight.colorNames
+            ))
+            // Continuous hover is stable when the button appears under the cursor —
+            // plain `.onHover` re-fires enter/exit as the overlay mounts, which flickers
+            // the button (and re-wraps the value text) in a loop.
+            .onContinuousHover { phase in
+                switch phase {
+                case .active: isHovering = true
+                case .ended: isHovering = false
+                }
             }
+            .animation(.easeInOut(duration: 0.2), value: allowContrast)
+            .animation(.easeInOut(duration: 0.2), value: allowPalettes)
+            .animation(.easeInOut(duration: 0.15), value: suppressed)
+            .animation(.easeInOut(duration: 0.15), value: isHovering)
         }
         .onAppear {
             if Defaults[.palettes].first?.pairs.isEmpty ?? true {
@@ -165,6 +288,69 @@ struct ContentView: View {
                 }
             }
         }
+    }
+}
+
+/// Shared surface for the footer and palette drawer. In light mode the under-window
+/// vibrancy material washes out to near-nothing, so use the standard window background
+/// for a clearly-defined panel; dark mode keeps the material, which reads well there.
+struct AdaptivePanelBackground: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        if colorScheme == .dark {
+            VisualEffect(
+                material: NSVisualEffectView.Material.underWindowBackground,
+                blendingMode: NSVisualEffectView.BlendingMode.behindWindow
+            )
+        } else {
+            Color(NSColor.windowBackgroundColor)
+        }
+    }
+}
+
+/// Divider that reads as a recessed seam in both appearances. The system `Divider`
+/// renders too light over the footer/drawer materials in light mode (looks white rather
+/// than a darker separator), so tint explicitly with `primary`, which flips per scheme.
+struct AdaptiveDivider: View {
+    @Environment(\.colorScheme) private var colorScheme
+    var axis: Axis = .horizontal
+
+    var body: some View {
+        Rectangle()
+            .fill(colorScheme == .dark ? Color.white.opacity(0.14) : Color.black.opacity(0.24))
+            .frame(
+                width: axis == .vertical ? 1 : nil,
+                height: axis == .horizontal ? 1 : nil
+            )
+    }
+}
+
+/// Small floating capsule shown when the adaptive layout is hiding enabled elements.
+/// Tapping it grows the window just enough to reveal them again.
+private struct ExpandToFitButton: View {
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 5.0) {
+                Image(systemName: "arrow.up.left.and.arrow.down.right")
+                    .font(.system(size: 10, weight: .semibold))
+                Text(PikaText.textExpandToFit)
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .padding(.horizontal, 10.0)
+            .padding(.vertical, 5.0)
+            .background(.regularMaterial, in: Capsule())
+            .overlay(Capsule().strokeBorder(Color.primary.opacity(0.12)))
+            .opacity(hovering ? 1.0 : 0.9)
+            .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 1)
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+        .onHover { hovering = $0 }
+        .help(PikaText.textExpandToFit)
     }
 }
 

--- a/Pika/Views/ContentView.swift
+++ b/Pika/Views/ContentView.swift
@@ -23,8 +23,8 @@ enum PikaAdaptiveWidth {
     static let base: CGFloat = 360 // bare minimum content width (matches window frame min)
     // Footer (with its shortened labels) and the palette drawer share one hide width so
     // they appear/disappear together — different values read as a bug.
-    static let palettes: CGFloat = 460
-    static let contrast: CGFloat = 460
+    static let palettes: CGFloat = 410
+    static let contrast: CGFloat = 410
     static let preview: CGFloat = 420 // preview pill
 }
 
@@ -170,8 +170,9 @@ struct ContentView: View {
 
                 if showCompliance, allowContrast {
                     AdaptiveDivider()
+                    // Slide only — no opacity fade, so the footer is always full opacity.
                     Footer(foreground: eyedroppers.foreground, background: eyedroppers.background)
-                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .transition(.move(edge: .bottom))
                 }
                 if historyDrawerVisible, allowPalettes {
                     ColorHistoryDrawer(foreground: eyedroppers.foreground, background: eyedroppers.background)

--- a/Pika/Views/EyedropperButton.swift
+++ b/Pika/Views/EyedropperButton.swift
@@ -7,6 +7,7 @@ struct EyedropperButton: View {
     @Default(.copyFormat) var copyFormat
     @Default(.hideColorNames) var hideColorNames
     @Default(.showColorPreview) var showColorPreview
+    @Environment(\.pikaAdaptiveVisibility) var adaptive
 
     @State var hoverVisible: Bool = false
     @State private var colorSpace = Defaults[.colorSpace]
@@ -20,25 +21,40 @@ struct EyedropperButton: View {
             }, label: {
                 ZStack {
                     VStack(alignment: .leading, spacing: 2.0) {
+                        // Visibility is size-aware (`adaptive.showsTypeLabels` already
+                        // folds in the preview-pill overlap) so labels fade out as the
+                        // window shrinks and return when it grows again.
+                        let showsTypeLabel = adaptive.showsTypeLabels
                         Text(eyedropper.type.description)
                             .font(.caption)
                             .fontWeight(.semibold)
                             .foregroundColor(eyedropper.color.getUIColor().opacity(0.75))
-                            .opacity(showColorPreview ? 0 : 1)
+                            .opacity(showsTypeLabel ? 1 : 0)
                             .animation(
-                                showColorPreview
-                                    ? .easeInOut(duration: 0.2)
-                                    : .easeInOut(duration: 0.25).delay(0.3),
-                                value: showColorPreview
+                                showsTypeLabel
+                                    ? .easeInOut(duration: 0.25).delay(0.3)
+                                    : .easeInOut(duration: 0.2),
+                                value: showsTypeLabel
                             )
 
                         VStack(alignment: .leading, spacing: 6.0) {
                             Text((eyedropper.color.usingColorSpace(colorSpace) ?? eyedropper.color).toFormat(format: colorFormat, style: copyFormat))
                                 .foregroundColor(eyedropper.color.getUIColor())
                                 .font(.system(size: 18, weight: .regular))
+                                // Shrink long formats (OKLCH/RGB) to stay within two
+                                // lines as the window narrows, rather than wrapping to
+                                // three lines or clipping. The trailing padding keeps the
+                                // text clear of the copy / system-picker hover buttons.
+                                .lineLimit(2)
+                                .minimumScaleFactor(0.5)
+                                // Bound the text to the column width (minus the button
+                                // gutter) so it wraps/scales inside its column instead of
+                                // reporting its single-line ideal width and overflowing
+                                // past the window edge.
                                 .padding(.trailing, 32.0)
+                                .frame(maxWidth: .infinity, alignment: .leading)
 
-                            if !hideColorNames {
+                            if !hideColorNames, adaptive.showsColorNames {
                                 Text(eyedropper.getClosestColor())
                                     .font(.system(size: 12, weight: .medium))
                                     .foregroundColor(eyedropper.color.getUIColor())

--- a/Pika/Views/EyedropperButton.swift
+++ b/Pika/Views/EyedropperButton.swift
@@ -1,6 +1,50 @@
 import Defaults
 import SwiftUI
 
+private struct ValueWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
+
+/// The colour value, shrunk to fit two lines as its column narrows. The font size is
+/// computed deterministically from the (font-independent) column width, so — unlike
+/// `minimumScaleFactor` + `lineLimit` — the wrap can't oscillate between one and two
+/// lines during a resize.
+struct AdaptiveValueText: View {
+    let value: String
+    let color: Color
+    private let baseSize: CGFloat = 18
+    private let minSize: CGFloat = 11
+    @State private var width: CGFloat = 0
+
+    private var fontSize: CGFloat {
+        guard width > 4 else { return baseSize }
+        let full = (value as NSString).size(withAttributes: [.font: NSFont.systemFont(ofSize: baseSize)]).width
+        guard full > 0 else { return baseSize }
+        // Scale the font *proportionally* with the column width so the wrap point stays
+        // put as the window resizes — no bistable jumping. The 1.5 factor (vs a
+        // theoretical 2 for two full lines) leaves slack for word-boundary wrapping, so
+        // long values still fit two lines instead of spilling to a truncated third.
+        let scale = min(1, (1.5 * width) / full)
+        return max(minSize, baseSize * scale)
+    }
+
+    var body: some View {
+        Text(value)
+            .foregroundColor(color)
+            .font(.system(size: fontSize, weight: .regular))
+            .lineLimit(2)
+            .truncationMode(.tail)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                GeometryReader { geo in
+                    Color.clear.preference(key: ValueWidthKey.self, value: geo.size.width)
+                }
+            )
+            .onPreferenceChange(ValueWidthKey.self) { width = $0 }
+    }
+}
+
 struct EyedropperButton: View {
     @ObservedObject var eyedropper: Eyedropper
     @Default(.colorFormat) var colorFormat
@@ -38,21 +82,15 @@ struct EyedropperButton: View {
                             )
 
                         VStack(alignment: .leading, spacing: 6.0) {
-                            Text((eyedropper.color.usingColorSpace(colorSpace) ?? eyedropper.color).toFormat(format: colorFormat, style: copyFormat))
-                                .foregroundColor(eyedropper.color.getUIColor())
-                                .font(.system(size: 18, weight: .regular))
-                                // Shrink long formats (OKLCH/RGB) to stay within two
-                                // lines as the window narrows, rather than wrapping to
-                                // three lines or clipping. The trailing padding keeps the
-                                // text clear of the copy / system-picker hover buttons.
-                                .lineLimit(2)
-                                .minimumScaleFactor(0.5)
-                                // Bound the text to the column width (minus the button
-                                // gutter) so it wraps/scales inside its column instead of
-                                // reporting its single-line ideal width and overflowing
-                                // past the window edge.
-                                .padding(.trailing, 32.0)
-                                .frame(maxWidth: .infinity, alignment: .leading)
+                            // Trailing gutter keeps the value clear of the copy /
+                            // system-picker hover buttons; the value itself shrinks to fit
+                            // two lines (see AdaptiveValueText).
+                            AdaptiveValueText(
+                                value: (eyedropper.color.usingColorSpace(colorSpace) ?? eyedropper.color)
+                                    .toFormat(format: colorFormat, style: copyFormat),
+                                color: Color(eyedropper.color.getUIColor())
+                            )
+                            .padding(.trailing, 32.0)
 
                             if !hideColorNames, adaptive.showsColorNames {
                                 Text(eyedropper.getClosestColor())

--- a/Pika/Views/Footer.swift
+++ b/Pika/Views/Footer.swift
@@ -65,7 +65,7 @@ private struct FooterRow: View {
                 }
             }
 
-            Divider()
+            AdaptiveDivider(axis: .vertical)
 
             VStack(alignment: .leading, spacing: 3.0) {
                 Text(complianceLabel)
@@ -152,7 +152,7 @@ private struct CompactBothFooter: View {
                 }
             }
 
-            Divider()
+            AdaptiveDivider()
                 .padding(.horizontal, -12.0)
 
             HStack(spacing: 6.0) {
@@ -207,10 +207,7 @@ struct Footer: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 12.0)
-        .background(VisualEffect(
-            material: NSVisualEffectView.Material.underWindowBackground,
-            blendingMode: NSVisualEffectView.BlendingMode.behindWindow
-        ))
+        .background(AdaptivePanelBackground())
     }
 }
 

--- a/Pika/Views/PreferencesView.swift
+++ b/Pika/Views/PreferencesView.swift
@@ -12,6 +12,7 @@ private struct GeneralAndSelectionSection: View {
         @Default(.betaUpdates) var betaUpdates
     #endif
     @Default(.hidePikaWhilePicking) var hidePikaWhilePicking
+    @Default(.windowShadow) var windowShadow
     @Default(.pickContrastingColor) var pickContrastingColor
     @Default(.appMode) var appMode
     @Default(.appFloating) var appFloating
@@ -52,6 +53,18 @@ private struct GeneralAndSelectionSection: View {
                         Text(PikaText.textIconDescription)
                     }
                 }
+
+                Text(PikaText.textWindowSettingsTitle)
+                    .font(.system(size: 16))
+                    .padding(.top, 8.0)
+                Picker("", selection: $windowShadow) {
+                    ForEach(WindowShadow.allCases, id: \.self) { value in
+                        Text(value.localizedString())
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .fixedSize()
             }
             .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
             .padding(.all, 24.0)

--- a/Pika/Views/Visualisation.swift
+++ b/Pika/Views/Visualisation.swift
@@ -1,11 +1,30 @@
 import MetalKit
 import SwiftUI
 
+/// Reports the hosting `NSWindow` up to SwiftUI so notification handlers can tell this
+/// window's events apart from those of transient popups (e.g. a Picker's menu window).
+private struct WindowAccessor: NSViewRepresentable {
+    @Binding var window: NSWindow?
+
+    func makeNSView(context _: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { window = view.window }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context _: Context) {
+        DispatchQueue.main.async {
+            if window == nil { window = nsView.window }
+        }
+    }
+}
+
 struct Visualisation: View {
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     var device: MTLDevice!
     @State var isShown = false
     @State var renderID = UUID()
+    @State private var hostWindow: NSWindow?
 
     init() {
         guard let device = MTLCreateSystemDefaultDevice() else {
@@ -34,24 +53,36 @@ struct Visualisation: View {
                 }
             }
         }
+        .background(WindowAccessor(window: $hostWindow))
         .animation(.easeIn(duration: 0.8), value: isShown)
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 isShown = true
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
+        // Only react to this view's own window. Otherwise a transient popup — like the
+        // menu window a Picker opens — fires willClose/didBecomeKey and wrongly toggles
+        // the shader (which made the header animation vanish when changing a dropdown).
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { note in
+            guard isHostWindow(note) else { return }
             if !isShown {
                 renderID = UUID()
                 isShown = true
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didMiniaturizeNotification)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didMiniaturizeNotification)) { note in
+            guard isHostWindow(note) else { return }
             isShown = false
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { note in
+            guard isHostWindow(note) else { return }
             isShown = false
         }
+    }
+
+    private func isHostWindow(_ note: Notification) -> Bool {
+        guard let hostWindow else { return false }
+        return (note.object as? NSWindow) === hostWindow
     }
 }
 


### PR DESCRIPTION
Closes #238.

Addresses both parts of the issue — the window shadow influencing colour readings, and the minimum window size being larger than necessary — plus a fair bit of related polish.

## Window shadow
- New **Window Settings** section in Preferences with a shadow dropdown: **Show shadow** / **Hide shadow while picking** / **Hide shadow**.
- "Hide shadow while picking" drops the shadow only for the duration of a pick (handling the chained foreground→background pick without flicker).
- When the window is shadowless it can blend into the desktop, so a **hairline border** is drawn via a borderless, click-through companion window laid over it (sized onto the visible glass edge, corner radius matched by eye since macOS masks the corners).

## Adaptive sizing
- Lowered the window minimum (~200pt tall, 360 wide) and shed UI as the window shrinks — palettes → contrast footer → preview pill → colour names → type labels — via height **and** width breakpoints, suppress-but-remember (saved toggles untouched).
- Footer and palette drawer share one hide width so they appear/disappear together; compliance badge titles truncate gracefully when tight.
- The colour value **shrinks to fit two lines** via proportional font scaling (`AdaptiveValueText`) — smooth on resize, no flicker, no truncation.
- Floating **expand-to-fit** control (hover-gated, tucks top-right at short heights) that grows the window to reveal hidden-but-enabled elements.

## Polish
- Shorter footer labels ("Contrast", "Contrast (Lc)", "Body").
- Standard window-background panels in light mode; `AdaptiveDivider` for consistent section seams; near-matched drawer tint; removed the divider between the two swatches.
- Fixed the Preferences header shader vanishing when a Picker menu closed (scoped the window notifications to the view's own window).

## Notes
- New preference/UI strings are English-only with English fallbacks in the other locales — they'll need real translations before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)