### PR TITLE
1.9.0

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,6 +65,8 @@ jobs:
 
           # Surface the full run output so a failing tag-mode run reports the
           # actual API error instead of an opaque "is_error" with no detail.
+          # Matches the reusable review workflow, which is debuggable for this
+          # exact reason.
           show_full_output: true
 
           # This is an optional setting that allows Claude to read CI results on PRs

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,15 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Serialise runs per issue/PR so rapid-fire @claude comments don't spawn
+# concurrent runs that race on context assembly (which yields an empty
+# formatted_context and an immediate is_error failure). Unlike the review
+# workflow we don't cancel in-progress runs — each @claude request is distinct
+# and worth completing.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |

--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -1266,7 +1266,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 93;
+				CURRENT_PROJECT_VERSION = 94;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Pika/Preview Content\"";
 				DEVELOPMENT_TEAM = TGHU37N6EX;
@@ -1280,7 +1280,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.9.0-beta2;
+				MARKETING_VERSION = 1.9.0-beta3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG TARGET_SPARKLE";
@@ -1298,7 +1298,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 93;
+				CURRENT_PROJECT_VERSION = 94;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Pika/Preview Content\"";
 				DEVELOPMENT_TEAM = TGHU37N6EX;
@@ -1312,7 +1312,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.9.0-beta2;
+				MARKETING_VERSION = 1.9.0-beta3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TARGET_SPARKLE;
@@ -1345,7 +1345,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.9.0-beta2;
+				MARKETING_VERSION = 1.9.0-beta3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG TARGET_MAS";
@@ -1378,7 +1378,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.9.0-beta2;
+				MARKETING_VERSION = 1.9.0-beta3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TARGET_MAS;

--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -1266,7 +1266,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Pika/Preview Content\"";
 				DEVELOPMENT_TEAM = TGHU37N6EX;
@@ -1280,7 +1280,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.9.0-beta1;
+				MARKETING_VERSION = 1.9.0-beta2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG TARGET_SPARKLE";
@@ -1298,7 +1298,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 92;
+				CURRENT_PROJECT_VERSION = 93;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Pika/Preview Content\"";
 				DEVELOPMENT_TEAM = TGHU37N6EX;
@@ -1312,7 +1312,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.9.0-beta1;
+				MARKETING_VERSION = 1.9.0-beta2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TARGET_SPARKLE;
@@ -1345,7 +1345,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.9.0-beta1;
+				MARKETING_VERSION = 1.9.0-beta2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG TARGET_MAS";
@@ -1378,7 +1378,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.9.0-beta1;
+				MARKETING_VERSION = 1.9.0-beta2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TARGET_MAS;

--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -1266,7 +1266,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Pika/Preview Content\"";
 				DEVELOPMENT_TEAM = TGHU37N6EX;
@@ -1280,7 +1280,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.9.0-beta1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG TARGET_SPARKLE";
@@ -1298,7 +1298,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 90;
+				CURRENT_PROJECT_VERSION = 92;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Pika/Preview Content\"";
 				DEVELOPMENT_TEAM = TGHU37N6EX;
@@ -1312,7 +1312,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.9.0-beta1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TARGET_SPARKLE;
@@ -1345,7 +1345,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.9.0-beta1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG TARGET_MAS";
@@ -1378,7 +1378,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.8.0;
+				MARKETING_VERSION = 1.9.0-beta1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhighfives.Pika;
 				PRODUCT_NAME = Pika;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TARGET_MAS;

--- a/Pika/AppDelegate.swift
+++ b/Pika/AppDelegate.swift
@@ -8,6 +8,13 @@ import SwiftUI
 #endif
 
 class AppDelegate: NSObject, NSApplicationDelegate {
+    /// The live app delegate. `NSApp.delegate` cannot be relied on here: under
+    /// `@NSApplicationDelegateAdaptor`, AppKit's `NSApp.delegate` is SwiftUI's own
+    /// forwarding wrapper (`SwiftUI.AppDelegate`), so `NSApp.delegate as? AppDelegate`
+    /// is always `nil` and any call chained off it silently no-ops. Capture the real
+    /// instance on launch and reach it through here instead.
+    weak static var shared: AppDelegate?
+
     var eyedroppers: Eyedroppers!
 
     let notificationCenter = NotificationCenter.default
@@ -52,6 +59,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillFinishLaunching(_: Notification) {
+        AppDelegate.shared = self
         NSApp.setActivationPolicy(.prohibited)
         NSAppleEventManager.shared().setEventHandler(
             URLSchemeHandler.shared,

--- a/Pika/Assets/de.lproj/Localizable.strings
+++ b/Pika/Assets/de.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "Beide";
 
 /* Contrast ratio */
-"color.ratio" = "Kontrastverhältnis";
+"color.ratio" = "Kontrast";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "Das Kontrastverhältnis ist ein Maß für den wahrgenommenen Helligkeitsunterschied zwischen zwei Farben, mit dem das Kontrastverhältnis berechnet wird.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Kontrastwert (Lc)";
+"color.lc" = "Kontrast (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "Der Helligkeitskontrast (Lc) ist ein Maß für den Helligkeitsunterschied zwischen zwei Farben, mit dem der Kontrastwert berechnet wird.";

--- a/Pika/Assets/de.lproj/Localizable.strings
+++ b/Pika/Assets/de.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "Vordergrund und Hintergrund auswählen";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "Fensterschatten";
+"preferences.shadow.options.always" = "Schatten anzeigen";
+"preferences.shadow.options.hiddenWhilePicking" = "Schatten während dem Auswählen verstecken";
+"preferences.shadow.options.never" = "Schatten verstecken";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "Zum Anpassen vergrößern";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "Fenstereinstellungen";

--- a/Pika/Assets/de.lproj/Localizable.strings
+++ b/Pika/Assets/de.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "Vordergrund und Hintergrund auswählen";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/de.lproj/Localizable.strings
+++ b/Pika/Assets/de.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/de.lproj/Localizable.strings
+++ b/Pika/Assets/de.lproj/Localizable.strings
@@ -448,6 +448,17 @@
 /* Appearance */
 "help.url.group.appearance" = "Erscheinungsbild";
 
+/* Pick foreground in a specific format */
+"help.url.pick.foreground_format" = "Vordergrund in bestimmtem Format auswählen";
+
+/* Pick background in a specific format */
+"help.url.pick.background_format" = "Hintergrund in bestimmtem Format auswählen";
+
+/* Copy foreground in a specific format */
+"help.url.copy.foreground_format" = "Vordergrund in bestimmtem Format kopieren";
+
+/* Copy background in a specific format */
+"help.url.copy.background_format" = "Hintergrund in bestimmtem Format kopieren";
 /* Set foreground color */
 "help.url.set.foreground" = "Vordergrundfarbe setzen";
 

--- a/Pika/Assets/en.lproj/Localizable.strings
+++ b/Pika/Assets/en.lproj/Localizable.strings
@@ -89,13 +89,13 @@
 "preferences.window.title" = "Window Settings";
 
 /* Window shadow: always on */
-"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.always" = "Show shadow";
 
 /* Window shadow: hidden while picking */
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
 
 /* Window shadow: never */
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand the window to fit hidden elements */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/en.lproj/Localizable.strings
+++ b/Pika/Assets/en.lproj/Localizable.strings
@@ -82,6 +82,24 @@
 /* Pick a contrasting background color after the foreground */
 "preferences.pick.contrasting" = "Pick contrasting color after foreground";
 
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";
+
+/* Window shadow: always on */
+"preferences.shadow.options.always" = "Shadow";
+
+/* Window shadow: hidden while picking */
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+
+/* Window shadow: never */
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand the window to fit hidden elements */
+"content.expandToFit" = "Expand to fit";
+
 /* General Settings */
 "preferences.general.title" = "General Settings";
 
@@ -161,13 +179,13 @@
 "color.standard.both" = "Both";
 
 /* Contrast ratio */
-"color.ratio" = "Contrast Ratio";
+"color.ratio" = "Contrast";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Contrast Value (Lc)";
+"color.lc" = "Contrast (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value.";
@@ -215,7 +233,7 @@
 "color.apca.title" = "Title";
 
 /* Body Text */
-"color.apca.body" = "Body Text";
+"color.apca.body" = "Body";
 
 /* Pass */
 "color.wcag.pass" = "Pass";

--- a/Pika/Assets/en.lproj/Localizable.strings
+++ b/Pika/Assets/en.lproj/Localizable.strings
@@ -505,6 +505,17 @@
 /* Appearance */
 "help.url.group.appearance" = "Appearance";
 
+/* Pick foreground in a specific format */
+"help.url.pick.foreground_format" = "Pick foreground in a specific format";
+
+/* Pick background in a specific format */
+"help.url.pick.background_format" = "Pick background in a specific format";
+
+/* Copy foreground in a specific format */
+"help.url.copy.foreground_format" = "Copy foreground in a specific format";
+
+/* Copy background in a specific format */
+"help.url.copy.background_format" = "Copy background in a specific format";
 /* Set foreground color */
 "help.url.set.foreground" = "Set foreground color";
 

--- a/Pika/Assets/es.lproj/Localizable.strings
+++ b/Pika/Assets/es.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "Seleccionar primer plano y segundo plano";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "Sombra de la ventana";
+"preferences.shadow.options.always" = "Mostrar sombra";
+"preferences.shadow.options.hiddenWhilePicking" = "Ocultar sombra durante la selección";
+"preferences.shadow.options.never" = "Ocultar sombra";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "Expandir para ajustar";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "Ajustes de Ventana";

--- a/Pika/Assets/es.lproj/Localizable.strings
+++ b/Pika/Assets/es.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "Ambos";
 
 /* Contrast ratio */
-"color.ratio" = "Proporción de contraste";
+"color.ratio" = "Contraste";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "La proporción de contraste es una medida de la diferencia en el brillo percibido entre dos colores, utilizada para calcular la proporción de contraste.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Valor de Contraste (Lc)";
+"color.lc" = "Contraste (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "El contraste de luminosidad (Lc) es una medida de la diferencia de luminosidad entre dos colores, utilizada para calcular el valor de contraste.";
@@ -212,7 +212,7 @@
 "color.apca.title" = "Título";
 
 /* Body Text */
-"color.apca.body" = "Texto del cuerpo";
+"color.apca.body" = "Cuerpo";
 
 /* Pass */
 "color.wcag.pass" = "Conforme";

--- a/Pika/Assets/es.lproj/Localizable.strings
+++ b/Pika/Assets/es.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "Seleccionar primer plano y segundo plano";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/es.lproj/Localizable.strings
+++ b/Pika/Assets/es.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/es.lproj/Localizable.strings
+++ b/Pika/Assets/es.lproj/Localizable.strings
@@ -448,6 +448,17 @@
 /* Appearance */
 "help.url.group.appearance" = "Apariencia";
 
+/* Pick foreground in a specific format */
+"help.url.pick.foreground_format" = "Seleccionar primer plano en un formato específico";
+
+/* Pick background in a specific format */
+"help.url.pick.background_format" = "Seleccionar segundo plano en un formato específico";
+
+/* Copy foreground in a specific format */
+"help.url.copy.foreground_format" = "Copiar primer plano en un formato específico";
+
+/* Copy background in a specific format */
+"help.url.copy.background_format" = "Copiar segundo plano en un formato específico";
 /* Set foreground color */
 "help.url.set.foreground" = "Establecer color de primer plano";
 

--- a/Pika/Assets/fr.lproj/Localizable.strings
+++ b/Pika/Assets/fr.lproj/Localizable.strings
@@ -164,7 +164,7 @@
 "color.ratio.description" = "Le rapport de contraste est une mesure de la différence de luminosité perçue entre deux couleurs, utilisée pour calculer le rapport de contraste.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Valeur de Contraste (Lc)";
+"color.lc" = "Contraste (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "Le contraste de luminosité (Lc) est une mesure de la différence de luminosité entre deux couleurs, utilisée pour calculer la valeur de contraste.";
@@ -212,7 +212,7 @@
 "color.apca.title" = "Titre";
 
 /* Body Text */
-"color.apca.body" = "Corps de texte";
+"color.apca.body" = "Corps";
 
 /* Pass */
 "color.wcag.pass" = "Conforme";

--- a/Pika/Assets/fr.lproj/Localizable.strings
+++ b/Pika/Assets/fr.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "Sélectionner premier plan et arrière-plan";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/fr.lproj/Localizable.strings
+++ b/Pika/Assets/fr.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "Sélectionner premier plan et arrière-plan";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "Ombre de la fenêtre";
+"preferences.shadow.options.always" = "Afficher l'ombre";
+"preferences.shadow.options.hiddenWhilePicking" = "Masquer l'ombre lors de la sélection";
+"preferences.shadow.options.never" = "Masquer l'ombre";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "Agrandir pour ajuster";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "Réglages de la fenêtre";

--- a/Pika/Assets/fr.lproj/Localizable.strings
+++ b/Pika/Assets/fr.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/fr.lproj/Localizable.strings
+++ b/Pika/Assets/fr.lproj/Localizable.strings
@@ -448,6 +448,17 @@
 /* Appearance */
 "help.url.group.appearance" = "Apparence";
 
+/* Pick foreground in a specific format */
+"help.url.pick.foreground_format" = "Sélectionner un premier plan dans un format spécifique";
+
+/* Pick background in a specific format */
+"help.url.pick.background_format" = "Sélectionner un arrière-plan dans un format spécifique";
+
+/* Copy foreground in a specific format */
+"help.url.copy.foreground_format" = "Copier le premier plan dans un format spécifique";
+
+/* Copy background in a specific format */
+"help.url.copy.background_format" = "Copier l'arrière-plan dans un format spécifique";
 /* Set foreground color */
 "help.url.set.foreground" = "Définir la couleur de premier plan";
 

--- a/Pika/Assets/hr.lproj/Localizable.strings
+++ b/Pika/Assets/hr.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "Obje";
 
 /* Contrast ratio */
-"color.ratio" = "Omjer kontrasta";
+"color.ratio" = "Kontrast";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "Omjer kontrasta je mjera razlike u percipiranoj svjetlini između dviju boja i koristi se za izračun omjera kontrasta.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Vrijednost kontrasta svjetline";
+"color.lc" = "Kontrast (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "Kontrast svjetline je mjera razlike u svjetlini između dviju boja i koristi se za izračun vrijednosti kontrasta.";
@@ -212,7 +212,7 @@
 "color.apca.title" = "Naslov";
 
 /* Body Text */
-"color.apca.body" = "Glavni tekst";
+"color.apca.body" = "Tekst";
 
 /* Pass */
 "color.wcag.pass" = "Uspjelo";

--- a/Pika/Assets/hr.lproj/Localizable.strings
+++ b/Pika/Assets/hr.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "Odaberi prednju i pozadinsku boju";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "Sjena prozora";
+"preferences.shadow.options.always" = "Prikaži sjenu";
+"preferences.shadow.options.hiddenWhilePicking" = "Sakrij sjenu tijekom biranja";
+"preferences.shadow.options.never" = "Sakrij sjenu";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "Proširi za prilagodbu";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "Postavke prozora";

--- a/Pika/Assets/hr.lproj/Localizable.strings
+++ b/Pika/Assets/hr.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/hr.lproj/Localizable.strings
+++ b/Pika/Assets/hr.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "Odaberi prednju i pozadinsku boju";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/hr.lproj/Localizable.strings
+++ b/Pika/Assets/hr.lproj/Localizable.strings
@@ -481,6 +481,17 @@
 /* Appearance */
 "help.url.group.appearance" = "Izgled";
 
+/* Pick foreground in a specific format */
+"help.url.pick.foreground_format" = "Odaberi prednju boju u određenom formatu";
+
+/* Pick background in a specific format */
+"help.url.pick.background_format" = "Odaberi boju pozadine u određenom formatu";
+
+/* Copy foreground in a specific format */
+"help.url.copy.foreground_format" = "Kopiraj prednju boju u određenom formatu";
+
+/* Copy background in a specific format */
+"help.url.copy.background_format" = "Kopiraj boju pozadine u određenom formatu";
 /* Set foreground color */
 "help.url.set.foreground" = "Postavi prednju boju";
 

--- a/Pika/Assets/ja.lproj/Localizable.strings
+++ b/Pika/Assets/ja.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "前景色と背景色をピック";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "ウインドウの影";
+"preferences.shadow.options.always" = "影を表示";
+"preferences.shadow.options.hiddenWhilePicking" = "ピック中は影を非表示";
+"preferences.shadow.options.never" = "影を非表示";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "広げて表示";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "ウインドウ設定";

--- a/Pika/Assets/ja.lproj/Localizable.strings
+++ b/Pika/Assets/ja.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "両方";
 
 /* Contrast ratio */
-"color.ratio" = "コントラスト比";
+"color.ratio" = "コントラスト";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "コントラスト比は2色間の知覚輝度の差を示す指標で、コントラスト比の計算に使用されます。";
 
 /* Contrast Value (Lc) */
-"color.lc" = "コントラスト値（Lc）";
+"color.lc" = "コントラスト（Lc）";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "輝度コントラスト（Lc）は2色間の明度差を示す指標で、コントラスト値の計算に使用されます。";

--- a/Pika/Assets/ja.lproj/Localizable.strings
+++ b/Pika/Assets/ja.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "前景色と背景色をピック";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/ja.lproj/Localizable.strings
+++ b/Pika/Assets/ja.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/ja.lproj/Localizable.strings
+++ b/Pika/Assets/ja.lproj/Localizable.strings
@@ -481,6 +481,17 @@
 /* Appearance */
 "help.url.group.appearance" = "外観";
 
+/* Pick foreground in a specific format */
+"help.url.pick.foreground_format" = "指定した形式で前景色をピック";
+
+/* Pick background in a specific format */
+"help.url.pick.background_format" = "指定した形式で背景色をピック";
+
+/* Copy foreground in a specific format */
+"help.url.copy.foreground_format" = "指定した形式で前景色をコピー";
+
+/* Copy background in a specific format */
+"help.url.copy.background_format" = "指定した形式で背景色をコピー";
 /* Set foreground color */
 "help.url.set.foreground" = "前景色を設定";
 

--- a/Pika/Assets/pl.lproj/Localizable.strings
+++ b/Pika/Assets/pl.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "Wybierz pierwszy plan i tło";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "Cień okna";
+"preferences.shadow.options.always" = "Pokaż cień";
+"preferences.shadow.options.hiddenWhilePicking" = "Ukryj cień podczas wybierania";
+"preferences.shadow.options.never" = "Ukryj cień";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "Rozwiń, aby dopasować";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "Ustawienia okna";

--- a/Pika/Assets/pl.lproj/Localizable.strings
+++ b/Pika/Assets/pl.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "Oba";
 
 /* Contrast ratio */
-"color.ratio" = "Współczynnik kontrastu";
+"color.ratio" = "Kontrast";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "Współczynnik kontrastu to miara różnicy w postrzeganej jasności dwóch kolorów, służąca do obliczenia współczynnika kontrastu.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Wartość kontrastu jasności (Lc)";
+"color.lc" = "Kontrast (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "Kontrast jasności (Lc) to miara różnicy jasności między dwoma kolorami, służąca do obliczenia wartości kontrastu.";
@@ -212,7 +212,7 @@
 "color.apca.title" = "Tytuł";
 
 /* Body Text */
-"color.apca.body" = "Tekst główny";
+"color.apca.body" = "Tekst";
 
 /* Pass */
 "color.wcag.pass" = "zaliczona";

--- a/Pika/Assets/pl.lproj/Localizable.strings
+++ b/Pika/Assets/pl.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "Wybierz pierwszy plan i tło";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/pl.lproj/Localizable.strings
+++ b/Pika/Assets/pl.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/pl.lproj/Localizable.strings
+++ b/Pika/Assets/pl.lproj/Localizable.strings
@@ -448,6 +448,17 @@
 /* Appearance */
 "help.url.group.appearance" = "Wygląd";
 
+/* Pick foreground in a specific format */
+"help.url.pick.foreground_format" = "Wybierz pierwszy plan w określonym formacie";
+
+/* Pick background in a specific format */
+"help.url.pick.background_format" = "Wybierz tło w określonym formacie";
+
+/* Copy foreground in a specific format */
+"help.url.copy.foreground_format" = "Kopiuj pierwszy plan w określonym formacie";
+
+/* Copy background in a specific format */
+"help.url.copy.background_format" = "Kopiuj tło w określonym formacie";
 /* Set foreground color */
 "help.url.set.foreground" = "Ustaw kolor pierwszego planu";
 

--- a/Pika/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hans.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "选择前景色和背景色";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hans.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "选择前景色和背景色";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "窗口阴影";
+"preferences.shadow.options.always" = "显示阴影";
+"preferences.shadow.options.hiddenWhilePicking" = "选择颜色时隐藏阴影";
+"preferences.shadow.options.never" = "隐藏阴影";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "展开以适应";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "窗口设置";

--- a/Pika/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hans.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "两者";
 
 /* Contrast ratio */
-"color.ratio" = "对比度比例";
+"color.ratio" = "对比度";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "对比度比例是衡量两种颜色之间感知亮度差异的指标，用于计算对比度比例。";
 
 /* Contrast Value (Lc) */
-"color.lc" = "对比值 (Lc)";
+"color.lc" = "对比度 (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "亮度对比度 (Lc) 是衡量两种颜色之间亮度差异的指标，用于计算对比值。";

--- a/Pika/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hans.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hans.lproj/Localizable.strings
@@ -448,6 +448,17 @@
 /* Appearance */
 "help.url.group.appearance" = "外观";
 
+/* Pick foreground in a specific format */
+"help.url.pick.foreground_format" = "以指定格式选择前景色";
+
+/* Pick background in a specific format */
+"help.url.pick.background_format" = "以指定格式选择背景色";
+
+/* Copy foreground in a specific format */
+"help.url.copy.foreground_format" = "以指定格式复制前景色";
+
+/* Copy background in a specific format */
+"help.url.copy.background_format" = "以指定格式复制背景色";
 /* Set foreground color */
 "help.url.set.foreground" = "设置前景色";
 

--- a/Pika/Assets/zh-Hant.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hant.lproj/Localizable.strings
@@ -549,3 +549,15 @@
 
 /* Pick foreground then background */
 "color.pick.contrast" = "選擇前景色和背景色";
+
+/* Window shadow */
+"preferences.shadow.description" = "Window shadow";
+"preferences.shadow.options.always" = "Shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
+"preferences.shadow.options.never" = "No shadow";
+
+/* Expand to fit */
+"content.expandToFit" = "Expand to fit";
+
+/* Window Settings */
+"preferences.window.title" = "Window Settings";

--- a/Pika/Assets/zh-Hant.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hant.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "選擇前景色和背景色";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "視窗陰影";
+"preferences.shadow.options.always" = "顯示陰影";
+"preferences.shadow.options.hiddenWhilePicking" = "選擇顏色時隱藏陰影";
+"preferences.shadow.options.never" = "隱藏陰影";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "展開以適應";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "視窗設置";

--- a/Pika/Assets/zh-Hant.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hant.lproj/Localizable.strings
@@ -552,9 +552,9 @@
 
 /* Window shadow */
 "preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "No shadow while picking";
-"preferences.shadow.options.never" = "No shadow";
+"preferences.shadow.options.always" = "Show shadow";
+"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
+"preferences.shadow.options.never" = "Hide shadow";
 
 /* Expand to fit */
 "content.expandToFit" = "Expand to fit";

--- a/Pika/Assets/zh-Hant.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hant.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "兩者";
 
 /* Contrast ratio */
-"color.ratio" = "對比度比例";
+"color.ratio" = "對比度";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "對比度比例是衡量兩種顏色之間感知亮度差異的指標，用於計算對比度比例。";
 
 /* Contrast Value (Lc) */
-"color.lc" = "對比值 (Lc)";
+"color.lc" = "對比度 (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "亮度對比度 (Lc) 是衡量兩種顏色之間亮度差異的指標，用於計算對比值。";

--- a/Pika/Assets/zh-Hant.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hant.lproj/Localizable.strings
@@ -448,6 +448,17 @@
 /* Appearance */
 "help.url.group.appearance" = "外觀";
 
+/* Pick foreground in a specific format */
+"help.url.pick.foreground_format" = "以指定格式選擇前景色";
+
+/* Pick background in a specific format */
+"help.url.pick.background_format" = "以指定格式選擇背景色";
+
+/* Copy foreground in a specific format */
+"help.url.copy.foreground_format" = "以指定格式複製前景色";
+
+/* Copy background in a specific format */
+"help.url.copy.background_format" = "以指定格式複製背景色";
 /* Set foreground color */
 "help.url.set.foreground" = "設定前景色";
 

--- a/Pika/Constants/Constants.swift
+++ b/Pika/Constants/Constants.swift
@@ -66,6 +66,7 @@ enum PikaConstants {
     static let ncSavePalette = "savePalette"
     static let ncExportPalette = "exportPalette"
     static let ncSystemColorChanged = "systemColorChanged"
+    static let ncExpandToFit = "expandToFit"
 
     // Disabled formats for SwiftUI copy format
     static let disabledFormats: [ColorFormat] = [.hex, .hsl, .opengl, .lab, .oklch]
@@ -102,4 +103,5 @@ extension Notification.Name {
     static let savePalette = Notification.Name(PikaConstants.ncSavePalette)
     static let exportPalette = Notification.Name(PikaConstants.ncExportPalette)
     static let systemColorChanged = Notification.Name(PikaConstants.ncSystemColorChanged)
+    static let expandToFit = Notification.Name(PikaConstants.ncExpandToFit)
 }

--- a/Pika/Constants/Defaults.swift
+++ b/Pika/Constants/Defaults.swift
@@ -46,6 +46,20 @@ enum ContrastStandard: String, Codable, CaseIterable {
     }
 }
 
+enum WindowShadow: String, Codable, CaseIterable {
+    case always = "preferences.shadow.options.always"
+    case hiddenWhilePicking = "preferences.shadow.options.hiddenWhilePicking"
+    case never = "preferences.shadow.options.never"
+
+    func localizedString() -> String {
+        NSLocalizedString(rawValue, comment: "Window Shadow")
+    }
+
+    /// The window's resting shadow state. `.hiddenWhilePicking` keeps the shadow at
+    /// rest and only drops it during an active pick (handled by the picker).
+    var showsShadowAtRest: Bool { self != .never }
+}
+
 enum AppMode: String, Codable, CaseIterable {
     case menubar = "preferences.app.mode.menubar"
     case regular = "preferences.app.mode.regular"
@@ -71,6 +85,7 @@ extension Defaults.Keys {
     static let colorFormat = Key<ColorFormat>("colorFormat", default: .hex)
     static let viewedSplash = Key<Bool>("viewedSplash", default: false)
     static let hidePikaWhilePicking = Key<Bool>("hidePikaWhilePicking", default: false)
+    static let windowShadow = Key<WindowShadow>("windowShadow", default: .always)
     static let pickContrastingColor = Key<Bool>("pickContrastingColor", default: false)
     static let copyColorOnPick = Key<Bool>("copyColorOnPick", default: false)
     static let hideMenuBarIcon = Key<Bool>("hideMenuBarIcon", default: false)

--- a/Pika/Constants/PikaText.swift
+++ b/Pika/Constants/PikaText.swift
@@ -172,6 +172,18 @@ enum PikaText {
         "preferences.pick.contrasting",
         comment: "Pick a contrasting background color after the foreground"
     )
+    static let textWindowShadow = NSLocalizedString(
+        "preferences.shadow.description",
+        comment: "Window shadow"
+    )
+    static let textWindowSettingsTitle = NSLocalizedString(
+        "preferences.window.title",
+        comment: "Window Settings"
+    )
+    static let textExpandToFit = NSLocalizedString(
+        "content.expandToFit",
+        comment: "Expand the window to fit hidden elements"
+    )
     static let textIconDescription = NSLocalizedString(
         "preferences.icon.description",
         comment: "Hide menu bar icon"

--- a/Pika/Constants/PikaText.swift
+++ b/Pika/Constants/PikaText.swift
@@ -307,6 +307,24 @@ enum PikaText {
     static let textUrlGroupCompliance = NSLocalizedString("help.url.group.compliance", comment: "Compliance")
     static let textUrlGroupPreview = NSLocalizedString("help.url.group.preview", comment: "Preview")
 
+    // URL Trigger Descriptions — Pick/Copy in Format
+    static let textUrlPickForegroundFormat = NSLocalizedString(
+        "help.url.pick.foreground_format",
+        comment: "Pick foreground in a specific format"
+    )
+    static let textUrlPickBackgroundFormat = NSLocalizedString(
+        "help.url.pick.background_format",
+        comment: "Pick background in a specific format"
+    )
+    static let textUrlCopyForegroundFormat = NSLocalizedString(
+        "help.url.copy.foreground_format",
+        comment: "Copy foreground in a specific format"
+    )
+    static let textUrlCopyBackgroundFormat = NSLocalizedString(
+        "help.url.copy.background_format",
+        comment: "Copy background in a specific format"
+    )
+
     // URL Trigger Descriptions — Set Color
     static let textUrlSetForeground = NSLocalizedString("help.url.set.foreground", comment: "Set foreground color")
     static let textUrlSetBackground = NSLocalizedString("help.url.set.background", comment: "Set background color")

--- a/Pika/Extensions/LookUpAPI.swift
+++ b/Pika/Extensions/LookUpAPI.swift
@@ -31,8 +31,6 @@ final class LookUpAPI {
         let (data, _) = try await session.data(for: request)
         let response = try jsonDecoder.decode(LookUpResponse.self, from: data)
 
-        print(response)
-
         return response.results.first.map {
             .init(version: $0.version,
                   minimumOsVersion: $0.minimumOsVersion,

--- a/Pika/Services/Eyedropper.swift
+++ b/Pika/Services/Eyedropper.swift
@@ -117,6 +117,12 @@ extension Eyedropper {
             NSApp.sendAction(#selector(AppDelegate.hidePika), to: nil, from: nil)
         }
 
+        // Drop the window's shadow while the sampler is up so it can't tint pixels
+        // picked near the window edge. Restored on every terminal pick path below;
+        // a chained background pick simply re-suppresses when it starts. The call is
+        // a no-op unless the shadow preference is `.hiddenWhilePicking`.
+        (NSApp.delegate as? AppDelegate)?.windowCoordinator.setPickingShadowSuppressed(true)
+
         DispatchQueue.main.asyncAfter(deadline: .now()) {
             if Defaults[.appMode].usesPopover {
                 NSApp.activate(ignoringOtherApps: true)
@@ -127,6 +133,10 @@ extension Eyedropper {
                     self.commitPick(selectedColor, chainContrasting: chainContrasting)
                 } else if self.pendingChainCommit {
                     self.commitCancelledChain()
+                } else {
+                    // Fresh pick cancelled: restore the shadow the sampler suppressed.
+                    (NSApp.delegate as? AppDelegate)?.windowCoordinator
+                        .setPickingShadowSuppressed(false)
                 }
 
                 if self.forceShow {
@@ -208,5 +218,9 @@ extension Eyedropper {
         } else {
             NSApp.sendAction(#selector(AppDelegate.showPika), to: nil, from: nil)
         }
+
+        // Terminal path for a committed pick (or a cancelled chain): bring the
+        // window's shadow back. No-op unless the shadow preference suppressed it.
+        (NSApp.delegate as? AppDelegate)?.windowCoordinator.setPickingShadowSuppressed(false)
     }
 }

--- a/Pika/Services/Eyedropper.swift
+++ b/Pika/Services/Eyedropper.swift
@@ -121,7 +121,7 @@ extension Eyedropper {
         // picked near the window edge. Restored on every terminal pick path below;
         // a chained background pick simply re-suppresses when it starts. The call is
         // a no-op unless the shadow preference is `.hiddenWhilePicking`.
-        (NSApp.delegate as? AppDelegate)?.windowCoordinator.setPickingShadowSuppressed(true)
+        AppDelegate.shared?.windowCoordinator.setPickingShadowSuppressed(true)
 
         DispatchQueue.main.asyncAfter(deadline: .now()) {
             if Defaults[.appMode].usesPopover {
@@ -135,8 +135,7 @@ extension Eyedropper {
                     self.commitCancelledChain()
                 } else {
                     // Fresh pick cancelled: restore the shadow the sampler suppressed.
-                    (NSApp.delegate as? AppDelegate)?.windowCoordinator
-                        .setPickingShadowSuppressed(false)
+                    AppDelegate.shared?.windowCoordinator.setPickingShadowSuppressed(false)
                 }
 
                 if self.forceShow {
@@ -174,7 +173,7 @@ extension Eyedropper {
 
         if chainContrasting,
            type == .foreground,
-           let appDelegate = NSApp.delegate as? AppDelegate
+           let appDelegate = AppDelegate.shared
         {
             startChainedBackgroundPick(using: appDelegate)
         } else {
@@ -221,6 +220,6 @@ extension Eyedropper {
 
         // Terminal path for a committed pick (or a cancelled chain): bring the
         // window's shadow back. No-op unless the shadow preference suppressed it.
-        (NSApp.delegate as? AppDelegate)?.windowCoordinator.setPickingShadowSuppressed(false)
+        AppDelegate.shared?.windowCoordinator.setPickingShadowSuppressed(false)
     }
 }

--- a/Pika/Services/PikaWindow.swift
+++ b/Pika/Services/PikaWindow.swift
@@ -26,15 +26,12 @@ class PikaWindow {
         // The window's drop shadow can bleed onto pixels beneath its edge and skew
         // colour readings taken nearby. Honour the user's shadow preference; the
         // `.hiddenWhilePicking` case keeps the resting shadow and is dropped mid-pick
-        // by `Eyedropper.start`.
+        // by `Eyedropper.start`. Setting *changes* (and the companion border shown while
+        // shadowless) are handled in `WindowCoordinator`.
         window.hasShadow = Defaults[.windowShadow].showsShadowAtRest
 
         Defaults.observe(.appFloating) { change in
             window.level = change.newValue == true ? .floating : .normal
-        }.tieToLifetime(of: self)
-
-        Defaults.observe(.windowShadow) { change in
-            window.hasShadow = change.newValue.showsShadowAtRest
         }.tieToLifetime(of: self)
 
         // Set up toolbar

--- a/Pika/Services/PikaWindow.swift
+++ b/Pika/Services/PikaWindow.swift
@@ -23,11 +23,10 @@ class PikaWindow {
         window.standardWindowButton(NSWindow.ButtonType.zoomButton)!.isEnabled = false
         window.titlebarAppearsTransparent = true
 
-        // The window's drop shadow can bleed onto pixels beneath its edge and skew
-        // colour readings taken nearby. Honour the user's shadow preference; the
-        // `.hiddenWhilePicking` case keeps the resting shadow and is dropped mid-pick
-        // by `Eyedropper.start`. Setting *changes* (and the companion border shown while
-        // shadowless) are handled in `WindowCoordinator`.
+        // The window's drop shadow can bleed onto pixels beneath its edge and skew colour
+        // readings taken nearby. Seed a sensible initial native shadow from the preference;
+        // `WindowCoordinator.applyShadowState` takes full ownership immediately after setup
+        // (including swapping in the custom, fadeable shadow for `.hiddenWhilePicking`).
         window.hasShadow = Defaults[.windowShadow].showsShadowAtRest
 
         Defaults.observe(.appFloating) { change in

--- a/Pika/Services/PikaWindow.swift
+++ b/Pika/Services/PikaWindow.swift
@@ -23,8 +23,18 @@ class PikaWindow {
         window.standardWindowButton(NSWindow.ButtonType.zoomButton)!.isEnabled = false
         window.titlebarAppearsTransparent = true
 
+        // The window's drop shadow can bleed onto pixels beneath its edge and skew
+        // colour readings taken nearby. Honour the user's shadow preference; the
+        // `.hiddenWhilePicking` case keeps the resting shadow and is dropped mid-pick
+        // by `Eyedropper.start`.
+        window.hasShadow = Defaults[.windowShadow].showsShadowAtRest
+
         Defaults.observe(.appFloating) { change in
             window.level = change.newValue == true ? .floating : .normal
+        }.tieToLifetime(of: self)
+
+        Defaults.observe(.windowShadow) { change in
+            window.hasShadow = change.newValue.showsShadowAtRest
         }.tieToLifetime(of: self)
 
         // Set up toolbar

--- a/Pika/Services/URLSchemeHandler.swift
+++ b/Pika/Services/URLSchemeHandler.swift
@@ -83,7 +83,7 @@ final class URLSchemeHandler: NSObject {
         guard
             let hex,
             hex.count == 6,
-            let appDelegate = NSApp.delegate as? AppDelegate
+            let appDelegate = AppDelegate.shared
         else { return }
         let color = NSColor(hex: hex)
         if task == "foreground" {
@@ -181,7 +181,7 @@ final class URLSchemeHandler: NSObject {
 
         // Apply the first history entry as the active colours
         if let first = autoHistory.pairs.first,
-           let appDelegate = NSApp.delegate as? AppDelegate
+           let appDelegate = AppDelegate.shared
         {
             appDelegate.eyedroppers.foreground.set(first.foregroundColor)
             appDelegate.eyedroppers.background.set(first.backgroundColor)

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -29,6 +29,40 @@ class WindowCoordinator: NSObject {
         // silently disabling frame autosave. Assign the name on the controller so it
         // sticks and AppKit persists size/position on move and resize.
         pikaTouchBarController.windowFrameAutosaveName = PikaWindow.primaryWindowAutosaveName
+
+        // The adaptive layout posts this when the user taps "expand to fit"; grow the
+        // window just enough to reveal the elements it's currently suppressing.
+        notificationCenter.addObserver(
+            forName: .expandToFit, object: nil, queue: .main
+        ) { [weak self] note in
+            guard let self, let size = (note.object as? NSValue)?.sizeValue else { return }
+            self.resizeMainWindow(toFitContent: size)
+        }
+    }
+
+    /// Grows the main window so its content area is at least `contentSize`, keeping the
+    /// top-left corner fixed (the natural anchor for a window being enlarged). Clamped to
+    /// the window's own min/max so it never fights the resize limits.
+    private func resizeMainWindow(toFitContent contentSize: NSSize) {
+        // `sizingOptions` mirrors the SwiftUI frame's min/max onto the window's content
+        // size limits, so clamp the request to those before converting to a window frame.
+        let minContent = pikaWindow.contentMinSize
+        let maxContent = pikaWindow.contentMaxSize
+        let targetContentWidth = min(max(contentSize.width, minContent.width), maxContent.width)
+        let targetContentHeight = min(max(contentSize.height, minContent.height), maxContent.height)
+
+        // Chrome (titlebar + toolbar) sits outside the SwiftUI content, so add the live
+        // inset to turn a content height into a window height. Width has no side chrome.
+        let chromeHeight = pikaWindow.frame.height - pikaWindow.contentLayoutRect.height
+
+        var frame = pikaWindow.frame
+        // Only ever grow — never shrink an axis that already has room.
+        let newWidth = max(frame.width, targetContentWidth)
+        let newHeight = max(frame.height, targetContentHeight + chromeHeight)
+        let top = frame.maxY
+        frame.size = NSSize(width: newWidth, height: newHeight)
+        frame.origin.y = top - newHeight
+        pikaWindow.setFrame(frame, display: true, animate: true)
     }
 
     /// Mounts the SwiftUI content tree on the main window. Call only when the active mode
@@ -38,10 +72,13 @@ class WindowCoordinator: NSObject {
         guard let eyedroppers = eyedroppers else { return }
         let contentView = ContentView()
             .environmentObject(eyedroppers)
-            .frame(minWidth: 480,
+            // Floor is well below the "everything visible" height: ContentView sheds
+            // elements adaptively as it shrinks (see PikaAdaptiveHeight), so the window
+            // can get compact again. Ideal stays at the comfortable first-launch size.
+            .frame(minWidth: 360,
                    idealWidth: 480,
                    maxWidth: 650,
-                   minHeight: 280,
+                   minHeight: 160,
                    idealHeight: 280,
                    maxHeight: 400,
                    alignment: .center)
@@ -56,6 +93,14 @@ class WindowCoordinator: NSObject {
 
     func removeMainWindowContent() {
         pikaWindow.contentView = nil
+    }
+
+    /// Drops or restores the main window's drop shadow around an active pick.
+    /// Only takes effect for `.hiddenWhilePicking`; the other modes keep their
+    /// resting shadow, which is owned by `PikaWindow`.
+    func setPickingShadowSuppressed(_ suppressed: Bool) {
+        guard Defaults[.windowShadow] == .hiddenWhilePicking else { return }
+        pikaWindow.hasShadow = !suppressed
     }
 
     func startMainWindow() {

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -12,6 +12,31 @@ class WindowCoordinator: NSObject {
     /// The border window extends this far beyond the main window frame so its outline can
     /// be drawn out on the window's visible glass edge (which sits just past the frame).
     private let borderPad: CGFloat = 6.0
+
+    /// A companion window that renders the main window's drop shadow ourselves, used only
+    /// in `.hiddenWhilePicking`. AppKit's native `hasShadow` is a plain on/off flag with no
+    /// public opacity control, so a *fade* on pick is impossible with it. This layer-backed
+    /// window sits behind the main window (its opaque fill is occluded; only the soft shadow
+    /// spills past the edges) and its `shadowOpacity` animates 1↔0 as picking starts/ends.
+    private var shadowWindow: NSWindow?
+    /// Room around the main frame for the soft shadow to spill without the window clipping it.
+    private let shadowPad: CGFloat = 60.0
+    /// Radius of the main window's visible rounded corners; the border stroke and the custom
+    /// shadow both trace this so they line up with the glass edge.
+    private let windowCornerRadius: CGFloat = 20.0
+    /// Resting opacity of the custom shadow when the window is focused, tuned to sit close
+    /// to the native macOS shadow.
+    private let focusedShadowOpacity: Float = 0.30
+    /// Resting opacity when the window isn't key — a lighter shadow, mirroring how AppKit
+    /// softens a native window's shadow once it loses focus.
+    private let unfocusedShadowOpacity: Float = 0.13
+    /// The resting opacity for the current focus state (ignores picking suppression).
+    private var restingShadowOpacity: Float {
+        pikaWindow?.isKeyWindow == true ? focusedShadowOpacity : unfocusedShadowOpacity
+    }
+
+    /// Whether an active pick currently wants the shadow suppressed. Drives the fade target.
+    private var isPickingSuppressed = false
     private var splashWindow: NSWindow!
     private var aboutWindow: NSWindow?
     private var helpWindow: NSWindow?
@@ -43,72 +68,175 @@ class WindowCoordinator: NSObject {
             self.resizeMainWindow(toFitContent: size)
         }
 
-        // Apply the shadow setting and show/hide the companion border to match.
-        Defaults.observe(.windowShadow) { [weak self] change in
-            guard let self else { return }
-            self.pikaWindow.hasShadow = change.newValue.showsShadowAtRest
-            self.updateShadowBorder()
+        // Re-apply the whole shadow configuration when the setting changes.
+        Defaults.observe(.windowShadow) { [weak self] _ in
+            self?.applyShadowState(animated: false)
         }.tieToLifetime(of: self)
 
-        // Keep the border on the same window level as the main window (which PikaWindow
-        // moves between .floating/.normal), so toggling "float on top" doesn't leave the
-        // border stranded on a stale level.
+        // Keep the companion windows on the same level as the main window (which PikaWindow
+        // moves between .floating/.normal), so toggling "float on top" doesn't leave them
+        // stranded on a stale level.
         Defaults.observe(.appFloating) { [weak self] change in
-            self?.borderWindow?.level = change.newValue == true ? .floating : .normal
+            let level: NSWindow.Level = change.newValue == true ? .floating : .normal
+            self?.borderWindow?.level = level
+            self?.shadowWindow?.level = level
         }.tieToLifetime(of: self)
 
-        // Keep the border aligned to the main window and re-attached whenever it shows.
+        // Keep the companion windows aligned to the main window as it resizes and moves.
         for name in [NSWindow.didResizeNotification, NSWindow.didMoveNotification] {
             notificationCenter.addObserver(forName: name, object: pikaWindow, queue: .main) {
                 [weak self] _ in
-                guard let self, let border = self.borderWindow, border.parent != nil else { return }
-                border.setFrame(self.borderFrame(), display: true)
+                self?.positionCompanionWindows()
             }
         }
-        notificationCenter.addObserver(
-            forName: NSWindow.didBecomeKeyNotification, object: pikaWindow, queue: .main
-        ) { [weak self] _ in
-            self?.updateShadowBorder()
+        // Focus changes fade the custom shadow between its focused and unfocused resting
+        // strengths (`didBecomeKey` also re-asserts the whole configuration on show).
+        for name in [NSWindow.didBecomeKeyNotification, NSWindow.didResignKeyNotification] {
+            notificationCenter.addObserver(forName: name, object: pikaWindow, queue: .main) {
+                [weak self] _ in
+                self?.applyShadowState(animated: true)
+            }
         }
 
-        updateShadowBorder()
+        applyShadowState(animated: false)
     }
 
-    /// The main window can lose its drop shadow (either via the setting or while picking),
-    /// which lets it blend into the desktop. A `.borderless`, click-through child window
-    /// laid exactly over it draws a hairline outline (matching the in-window dividers) so
-    /// the edge stays defined. Shown only while the window is shadowless.
-    func updateShadowBorder() {
+    /// Applies the full shadow configuration for the current setting and picking state.
+    /// Each mode owns a coherent trio of decisions — native shadow, the custom (fadeable)
+    /// shadow, and the hairline edge border:
+    ///   • `.always`  — native drop shadow, no companions.
+    ///   • `.never`   — no shadow; the hairline border keeps the (otherwise blending) edge.
+    ///   • `.hiddenWhilePicking` — native shadow off, custom shadow drawn instead so it can
+    ///     fade to nothing while the sampler is up (and the border fades in to hold the edge).
+    /// `animated` is `true` only for the pick transition; setting changes and re-asserts snap.
+    func applyShadowState(animated: Bool = false) {
         guard pikaWindow != nil else { return }
 
-        guard !pikaWindow.hasShadow else {
-            if let border = borderWindow {
-                pikaWindow.removeChildWindow(border)
-                border.orderOut(nil)
-            }
-            return
+        switch Defaults[.windowShadow] {
+        case .always:
+            setNativeShadow(true)
+            teardownCustomShadow()
+            setBorderVisible(false, animated: animated)
+        case .never:
+            setNativeShadow(false)
+            teardownCustomShadow()
+            setBorderVisible(true, animated: animated)
+        case .hiddenWhilePicking:
+            // The native shadow can't animate, so we render our own and fade it.
+            setNativeShadow(false)
+            ensureCustomShadow()
+            setCustomShadowOpacity(isPickingSuppressed ? 0 : restingShadowOpacity, animated: animated)
+            // The edge only needs the hairline while the shadow is gone; crossfade it in.
+            setBorderVisible(isPickingSuppressed, animated: animated)
         }
+    }
 
-        let border = borderWindow ?? makeBorderWindow()
-        borderWindow = border
-        border.setFrame(borderFrame(), display: true)
-        if border.parent == nil {
-            pikaWindow.addChildWindow(border, ordered: .above)
+    private func setNativeShadow(_ hasShadow: Bool) {
+        pikaWindow.hasShadow = hasShadow
+        // AppKit caches a visible window's drop shadow: flipping `hasShadow` on an
+        // already-onscreen window doesn't take effect until it's moved, resized, or
+        // reordered. Force the recompute so the change lands immediately.
+        pikaWindow.invalidateShadow()
+    }
+
+    // MARK: Companion windows (hairline border + custom shadow)
+
+    /// Repositions both companion windows to track the main window's current frame.
+    private func positionCompanionWindows() {
+        if let border = borderWindow, border.parent != nil {
+            border.setFrame(borderFrame(), display: true)
         }
-        border.level = pikaWindow.level
+        if let shadow = shadowWindow, shadow.parent != nil {
+            shadow.setFrame(shadowFrame(), display: true)
+        }
+    }
+
+    /// Shows or hides the hairline edge border, fading its alpha when `animated`. Never
+    /// creates the border just to hide it.
+    private func setBorderVisible(_ visible: Bool, animated: Bool) {
+        if !visible, borderWindow == nil { return }
+        let border = ensureBorderWindow()
+        border.setFrame(borderFrame(), display: true)
+        let target: CGFloat = visible ? 1 : 0
+        if animated {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.28
+                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                border.animator().alphaValue = target
+            }
+        } else {
+            border.alphaValue = target
+        }
+    }
+
+    private func ensureBorderWindow() -> NSWindow {
+        if let border = borderWindow {
+            if border.parent == nil { pikaWindow.addChildWindow(border, ordered: .above) }
+            return border
+        }
+        let border = makeBorderWindow()
+        border.alphaValue = 0
         if let borderView = border.contentView as? ShadowBorderView {
             // Sit the stroke on the main window's frame edge (which lines up with the
             // visible glass edge), and match the window's rounded-corner radius.
             borderView.strokeInset = borderPad
-            borderView.cornerRadius = 20
+            borderView.cornerRadius = windowCornerRadius
         }
-        border.orderFront(nil)
-        border.contentView?.needsDisplay = true
+        borderWindow = border
+        pikaWindow.addChildWindow(border, ordered: .above)
+        border.level = pikaWindow.level
+        return border
+    }
+
+    private func ensureCustomShadow() {
+        let shadow = shadowWindow ?? makeShadowWindow()
+        shadowWindow = shadow
+        shadow.setFrame(shadowFrame(), display: true)
+        if shadow.parent == nil { pikaWindow.addChildWindow(shadow, ordered: .below) }
+        shadow.level = pikaWindow.level
+    }
+
+    private func teardownCustomShadow() {
+        guard let shadow = shadowWindow else { return }
+        pikaWindow.removeChildWindow(shadow)
+        shadow.orderOut(nil)
+        shadowWindow = nil
+    }
+
+    private func setCustomShadowOpacity(_ opacity: Float, animated: Bool) {
+        (shadowWindow?.contentView as? ShadowCasterView)?.setShadowOpacity(opacity, animated: animated)
     }
 
     /// The border window frame — the main window's frame grown by `borderPad` on all sides.
     private func borderFrame() -> NSRect {
         pikaWindow.frame.insetBy(dx: -borderPad, dy: -borderPad)
+    }
+
+    /// The shadow window frame — the main window's frame grown by `shadowPad` so the soft
+    /// shadow has room to spill without the window clipping it.
+    private func shadowFrame() -> NSRect {
+        pikaWindow.frame.insetBy(dx: -shadowPad, dy: -shadowPad)
+    }
+
+    private func makeShadowWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: shadowFrame(),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = false
+        window.ignoresMouseEvents = true
+        window.isReleasedWhenClosed = false
+        window.level = pikaWindow.level
+        let caster = ShadowCasterView(frame: shadowFrame())
+        caster.pad = shadowPad
+        caster.cornerRadius = windowCornerRadius
+        caster.restingOpacity = restingShadowOpacity
+        window.contentView = caster
+        return window
     }
 
     private func makeBorderWindow() -> NSWindow {
@@ -185,26 +313,26 @@ class WindowCoordinator: NSObject {
         pikaWindow.contentView = nil
     }
 
-    /// Drops or restores the main window's drop shadow around an active pick.
-    /// Only takes effect for `.hiddenWhilePicking`; the other modes keep their
-    /// resting shadow, which is owned by `PikaWindow`.
+    /// Fades the main window's drop shadow out (and the edge border in) around an active
+    /// pick, and back when it ends. Only `.hiddenWhilePicking` reacts; the other modes have
+    /// no custom shadow to fade, so this is a no-op for them.
     func setPickingShadowSuppressed(_ suppressed: Bool) {
-        guard Defaults[.windowShadow] == .hiddenWhilePicking else { return }
-        pikaWindow.hasShadow = !suppressed
-        updateShadowBorder()
+        guard isPickingSuppressed != suppressed else { return }
+        isPickingSuppressed = suppressed
+        applyShadowState(animated: true)
     }
 
     func startMainWindow() {
         if !pikaWindow.isVisible {
             pikaWindow.fadeIn(nil)
         }
-        updateShadowBorder()
+        applyShadowState()
         Defaults[.viewedSplash] = true
     }
 
     func showMainWindow() {
         pikaWindow.makeKeyAndOrderFront(nil)
-        updateShadowBorder()
+        applyShadowState()
     }
 
     func hideMainWindow() {
@@ -232,7 +360,7 @@ class WindowCoordinator: NSObject {
         } else {
             pikaWindow.fadeIn(sender: nil, duration: 0.2)
         }
-        updateShadowBorder()
+        applyShadowState()
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -344,5 +472,86 @@ private final class ShadowBorderView: NSView {
         path.lineWidth = 1.0
         color.setStroke()
         path.stroke()
+    }
+}
+
+/// Casts the main window's drop shadow ourselves so its opacity can animate — AppKit's
+/// native `hasShadow` can't. A rounded-rect fill (sized to the main window and occluded by
+/// it, since this window sits just behind) throws a soft `CALayer` shadow that spills past
+/// the window edges into the surrounding `shadowPad`. Only `shadowOpacity` is animated.
+private final class ShadowCasterView: NSView {
+    /// Distance from the view edge in to the fill rect — matches `WindowCoordinator.shadowPad`
+    /// so the fill lines up exactly with the main window and the shadow spills into the rest.
+    var pad: CGFloat = 60.0 { didSet { needsLayout = true } }
+    /// Corner radius of the main window's visible edge, traced by the fill and shadow.
+    var cornerRadius: CGFloat = 20.0 { didSet { needsLayout = true } }
+    /// Full-strength (resting) shadow opacity; the initial value before any fade.
+    var restingOpacity: Float = 0.30 {
+        didSet { fillLayer.shadowOpacity = restingOpacity }
+    }
+
+    private let fillLayer = CALayer()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.masksToBounds = false
+        // Fill colour is irrelevant to the shadow and is occluded by the main window; a
+        // sliver could show at the very corners, so use the window background rather than a
+        // stark black so any leak blends in. The shadow itself is always black.
+        fillLayer.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        fillLayer.shadowColor = NSColor.black.cgColor
+        fillLayer.shadowOffset = CGSize(width: 0, height: -8)
+        fillLayer.shadowRadius = 18
+        fillLayer.shadowOpacity = restingOpacity
+        layer?.addSublayer(fillLayer)
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        withoutImplicitAnimation {
+            fillLayer.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        }
+    }
+
+    override func layout() {
+        super.layout()
+        // Nudge the fill 0.5pt inside the main window's edge so its corners stay tucked
+        // under the (opaque) window even if the real corner radius differs slightly.
+        let rect = bounds.insetBy(dx: pad + 0.5, dy: pad + 0.5)
+        withoutImplicitAnimation {
+            fillLayer.frame = rect
+            fillLayer.cornerRadius = cornerRadius
+            fillLayer.shadowPath = CGPath(
+                roundedRect: CGRect(origin: .zero, size: rect.size),
+                cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil
+            )
+        }
+    }
+
+    /// Fades (or snaps) the shadow to `opacity`. Reads the presentation layer so a fade that
+    /// interrupts another lands smoothly rather than jumping to the model value first.
+    func setShadowOpacity(_ opacity: Float, animated: Bool) {
+        if animated {
+            let animation = CABasicAnimation(keyPath: "shadowOpacity")
+            animation.fromValue = fillLayer.presentation()?.shadowOpacity ?? fillLayer.shadowOpacity
+            animation.toValue = opacity
+            animation.duration = 0.28
+            animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            fillLayer.add(animation, forKey: "shadowOpacity")
+            fillLayer.shadowOpacity = opacity
+        } else {
+            withoutImplicitAnimation { fillLayer.shadowOpacity = opacity }
+        }
+    }
+
+    private func withoutImplicitAnimation(_ body: () -> Void) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        body()
+        CATransaction.commit()
     }
 }

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -50,6 +50,13 @@ class WindowCoordinator: NSObject {
             self.updateShadowBorder()
         }.tieToLifetime(of: self)
 
+        // Keep the border on the same window level as the main window (which PikaWindow
+        // moves between .floating/.normal), so toggling "float on top" doesn't leave the
+        // border stranded on a stale level.
+        Defaults.observe(.appFloating) { [weak self] change in
+            self?.borderWindow?.level = change.newValue == true ? .floating : .normal
+        }.tieToLifetime(of: self)
+
         // Keep the border aligned to the main window and re-attached whenever it shows.
         for name in [NSWindow.didResizeNotification, NSWindow.didMoveNotification] {
             notificationCenter.addObserver(forName: name, object: pikaWindow, queue: .main) {
@@ -88,9 +95,10 @@ class WindowCoordinator: NSObject {
         if border.parent == nil {
             pikaWindow.addChildWindow(border, ordered: .above)
         }
+        border.level = pikaWindow.level
         if let borderView = border.contentView as? ShadowBorderView {
-            // Push the stroke ~1.5pt beyond the main frame edge so it lands on the visible
-            // glass edge, and match the window's rounded-corner radius.
+            // Sit the stroke on the main window's frame edge (which lines up with the
+            // visible glass edge), and match the window's rounded-corner radius.
             borderView.strokeInset = borderPad
             borderView.cornerRadius = 20
         }

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -8,6 +8,10 @@ class WindowCoordinator: NSObject {
     weak var eyedroppers: Eyedroppers?
 
     private(set) var pikaWindow: NSWindow!
+    private var borderWindow: NSWindow?
+    /// The border window extends this far beyond the main window frame so its outline can
+    /// be drawn out on the window's visible glass edge (which sits just past the frame).
+    private let borderPad: CGFloat = 6.0
     private var splashWindow: NSWindow!
     private var aboutWindow: NSWindow?
     private var helpWindow: NSWindow?
@@ -38,6 +42,82 @@ class WindowCoordinator: NSObject {
             guard let self, let size = (note.object as? NSValue)?.sizeValue else { return }
             self.resizeMainWindow(toFitContent: size)
         }
+
+        // Apply the shadow setting and show/hide the companion border to match.
+        Defaults.observe(.windowShadow) { [weak self] change in
+            guard let self else { return }
+            self.pikaWindow.hasShadow = change.newValue.showsShadowAtRest
+            self.updateShadowBorder()
+        }.tieToLifetime(of: self)
+
+        // Keep the border aligned to the main window and re-attached whenever it shows.
+        for name in [NSWindow.didResizeNotification, NSWindow.didMoveNotification] {
+            notificationCenter.addObserver(forName: name, object: pikaWindow, queue: .main) {
+                [weak self] _ in
+                guard let self, let border = self.borderWindow, border.parent != nil else { return }
+                border.setFrame(self.borderFrame(), display: true)
+            }
+        }
+        notificationCenter.addObserver(
+            forName: NSWindow.didBecomeKeyNotification, object: pikaWindow, queue: .main
+        ) { [weak self] _ in
+            self?.updateShadowBorder()
+        }
+
+        updateShadowBorder()
+    }
+
+    /// The main window can lose its drop shadow (either via the setting or while picking),
+    /// which lets it blend into the desktop. A `.borderless`, click-through child window
+    /// laid exactly over it draws a hairline outline (matching the in-window dividers) so
+    /// the edge stays defined. Shown only while the window is shadowless.
+    func updateShadowBorder() {
+        guard pikaWindow != nil else { return }
+
+        guard !pikaWindow.hasShadow else {
+            if let border = borderWindow {
+                pikaWindow.removeChildWindow(border)
+                border.orderOut(nil)
+            }
+            return
+        }
+
+        let border = borderWindow ?? makeBorderWindow()
+        borderWindow = border
+        border.setFrame(borderFrame(), display: true)
+        if border.parent == nil {
+            pikaWindow.addChildWindow(border, ordered: .above)
+        }
+        if let borderView = border.contentView as? ShadowBorderView {
+            // Push the stroke ~1.5pt beyond the main frame edge so it lands on the visible
+            // glass edge, and match the window's rounded-corner radius.
+            borderView.strokeInset = borderPad
+            borderView.cornerRadius = 20
+        }
+        border.orderFront(nil)
+        border.contentView?.needsDisplay = true
+    }
+
+    /// The border window frame — the main window's frame grown by `borderPad` on all sides.
+    private func borderFrame() -> NSRect {
+        pikaWindow.frame.insetBy(dx: -borderPad, dy: -borderPad)
+    }
+
+    private func makeBorderWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: borderFrame(),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.hasShadow = false
+        window.ignoresMouseEvents = true
+        window.isReleasedWhenClosed = false
+        window.level = pikaWindow.level
+        window.contentView = ShadowBorderView()
+        return window
     }
 
     /// Grows the main window so its content area is at least `contentSize`, keeping the
@@ -75,13 +155,15 @@ class WindowCoordinator: NSObject {
             // Floor is well below the "everything visible" height: ContentView sheds
             // elements adaptively as it shrinks (see PikaAdaptiveHeight), so the window
             // can get compact again. Ideal stays at the comfortable first-launch size.
-            .frame(minWidth: 360,
-                   idealWidth: 480,
-                   maxWidth: 650,
-                   minHeight: 160,
-                   idealHeight: 280,
-                   maxHeight: 400,
-                   alignment: .center)
+            .frame(
+                minWidth: 360,
+                idealWidth: 480,
+                maxWidth: 650,
+                minHeight: 160,
+                idealHeight: 280,
+                maxHeight: 400,
+                alignment: .center
+            )
         let hostingView = NSHostingView(rootView: contentView)
         // Apply the SwiftUI min/max as the window's resize limits, but omit
         // `.intrinsicContentSize` so the hosting view doesn't snap the window back
@@ -101,17 +183,20 @@ class WindowCoordinator: NSObject {
     func setPickingShadowSuppressed(_ suppressed: Bool) {
         guard Defaults[.windowShadow] == .hiddenWhilePicking else { return }
         pikaWindow.hasShadow = !suppressed
+        updateShadowBorder()
     }
 
     func startMainWindow() {
         if !pikaWindow.isVisible {
             pikaWindow.fadeIn(nil)
         }
+        updateShadowBorder()
         Defaults[.viewedSplash] = true
     }
 
     func showMainWindow() {
         pikaWindow.makeKeyAndOrderFront(nil)
+        updateShadowBorder()
     }
 
     func hideMainWindow() {
@@ -119,7 +204,9 @@ class WindowCoordinator: NSObject {
     }
 
     func closeSplashWindow() {
-        splashWindow.fadeOut(sender: nil, duration: 0.25, closeSelector: .close, completionHandler: startMainWindow)
+        splashWindow.fadeOut(
+            sender: nil, duration: 0.25, closeSelector: .close, completionHandler: startMainWindow
+        )
     }
 
     func togglePopover() {
@@ -137,6 +224,7 @@ class WindowCoordinator: NSObject {
         } else {
             pikaWindow.fadeIn(sender: nil, duration: 0.2)
         }
+        updateShadowBorder()
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -216,5 +304,37 @@ class WindowCoordinator: NSObject {
         splashTouchBarController = SplashTouchBarController(window: splashWindow)
         splashWindow.contentView = NSHostingView(rootView: SplashView().ignoresSafeArea())
         splashWindow.fadeIn(nil)
+    }
+}
+
+/// Draws the main window's hairline outline for the companion border window. Strokes a
+/// rounded rect matching the window's corner radius, in a colour that adapts to the
+/// current appearance (matching `AdaptiveDivider`).
+private final class ShadowBorderView: NSView {
+    /// Corner radius of the window's visible edge.
+    var cornerRadius: CGFloat = 16.0 { didSet { needsDisplay = true } }
+    /// How far the stroke sits inside the view bounds. The view is larger than the main
+    /// window frame (see `WindowCoordinator.borderPad`); reducing this pushes the outline
+    /// outward to sit on the window's visible glass edge rather than its frame.
+    var strokeInset: CGFloat = 4.0 { didSet { needsDisplay = true } }
+
+    override var allowsVibrancy: Bool { false }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsDisplay = true
+    }
+
+    override func draw(_: NSRect) {
+        let isDark = effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+        let color =
+            isDark
+                ? NSColor.white.withAlphaComponent(0.14)
+                : NSColor.black.withAlphaComponent(0.24)
+        let rect = bounds.insetBy(dx: strokeInset, dy: strokeInset)
+        let path = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
+        path.lineWidth = 1.0
+        color.setStroke()
+        path.stroke()
     }
 }

--- a/Pika/TouchBar/PikaTouchBar.swift
+++ b/Pika/TouchBar/PikaTouchBar.swift
@@ -148,7 +148,7 @@ class PikaTouchBarController: NSWindowController, NSTouchBarDelegate {
         _: NSTouchBar,
         makeItemForIdentifier identifier: NSTouchBarItem.Identifier
     ) -> NSTouchBarItem? {
-        let delegate = NSApplication.shared.delegate as? AppDelegate
+        let delegate = AppDelegate.shared
         let foreground = delegate!.eyedroppers.foreground
         let background = delegate!.eyedroppers.background
 

--- a/Pika/Views/ColorHistoryDrawer.swift
+++ b/Pika/Views/ColorHistoryDrawer.swift
@@ -11,6 +11,7 @@ struct ColorHistoryDrawer: View {
     @ObservedObject var background: Eyedropper
     @Default(.palettes) var palettes
     @Default(.activePaletteIndex) var activePaletteIndex
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var isShowingClearConfirm = false
     @State private var slideDirection: VerticalDirection = .down
@@ -29,10 +30,10 @@ struct ColorHistoryDrawer: View {
     }
 
     var body: some View {
-        Divider()
+        AdaptiveDivider()
         VStack(spacing: 0) {
             PaletteTabBar(slideDirection: $slideDirection)
-            Divider()
+            AdaptiveDivider()
             HStack(spacing: 0) {
                 ZStack {
                     ScrollView(.horizontal, showsIndicators: false) {
@@ -72,7 +73,7 @@ struct ColorHistoryDrawer: View {
                 }
 
                 HStack(spacing: 0) {
-                    Divider()
+                    AdaptiveDivider(axis: .vertical)
 
                     if isAutoHistory {
                         Button(action: { isShowingClearConfirm = true }) {
@@ -106,11 +107,10 @@ struct ColorHistoryDrawer: View {
         }
         .background(
             ZStack {
-                VisualEffect(
-                    material: NSVisualEffectView.Material.underWindowBackground,
-                    blendingMode: NSVisualEffectView.BlendingMode.behindWindow
-                )
-                Color.black.opacity(0.2)
+                AdaptivePanelBackground()
+                // Barely-there tint so the drawer reads as almost the same surface as the
+                // contrast footer — just a whisper of separation.
+                Color.black.opacity(colorScheme == .dark ? 0.06 : 0.02)
             }
         )
         .alert(PikaText.textHistoryClear, isPresented: $isShowingClearConfirm) {

--- a/Pika/Views/ColorPickers.swift
+++ b/Pika/Views/ColorPickers.swift
@@ -7,10 +7,9 @@ struct ColorPickers: View {
         let eyedropperArray: [Eyedropper] = [eyedroppers.foreground, eyedroppers.background]
 
         HStack(spacing: 0.0) {
-            ForEach(Array(eyedropperArray.enumerated()), id: \.element.type) { index, eyedropper in
-                if index > 0 {
-                    Divider()
-                }
+            ForEach(Array(eyedropperArray.enumerated()), id: \.element.type) { _, eyedropper in
+                // No divider between the two swatches — the colours meet directly, and the
+                // horizontal section dividers do the framing.
                 EyedropperItem(eyedropper: eyedropper)
             }
         }

--- a/Pika/Views/ComplianceButtons.swift
+++ b/Pika/Views/ComplianceButtons.swift
@@ -1,6 +1,39 @@
 import Defaults
 import SwiftUI
 
+private struct NaturalWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = max(value, nextValue()) }
+}
+
+/// Renders `content` at its natural (untruncated) width, then uniformly scales it down to
+/// fit the available width. The preview tiles are narrower than the full compliance badges
+/// need, and laying the badges out at the tile width just truncates them ("AA…La…"); this
+/// keeps them whole and legible by shrinking instead.
+private struct ScaleToFitWidth<Content: View>: View {
+    var alignment: Alignment = .leading
+    @ViewBuilder var content: Content
+    @State private var naturalWidth: CGFloat = 0
+
+    private var anchor: UnitPoint { alignment == .center ? .center : .leading }
+
+    var body: some View {
+        GeometryReader { geo in
+            let scale = naturalWidth > 0 ? min(1, geo.size.width / naturalWidth) : 1
+            content
+                .fixedSize()
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(key: NaturalWidthKey.self, value: proxy.size.width)
+                    }
+                )
+                .scaleEffect(scale, anchor: anchor)
+                .frame(width: geo.size.width, height: geo.size.height, alignment: alignment)
+        }
+        .onPreferenceChange(NaturalWidthKey.self) { naturalWidth = $0 }
+    }
+}
+
 struct CompliancePreviewWCAG: View {
     @Default(.combineCompliance) var combineCompliance
     var width: CGFloat
@@ -14,9 +47,11 @@ struct CompliancePreviewWCAG: View {
             Button(
                 action: { combineCompliance = false },
                 label: {
-                    ComplianceToggleGroup(complianceData: .wcag(wcag), theme: .weight)
-                        .padding(20.0)
-                        .frame(maxWidth: width, maxHeight: .infinity, alignment: .leading)
+                    ScaleToFitWidth {
+                        ComplianceToggleGroup(complianceData: .wcag(wcag), theme: .weight)
+                            .padding(20.0)
+                    }
+                    .frame(maxWidth: width, maxHeight: .infinity, alignment: .leading)
                 }
             )
             .buttonStyle(AppearanceButtonStyle(
@@ -28,9 +63,11 @@ struct CompliancePreviewWCAG: View {
             Button(
                 action: { combineCompliance = true },
                 label: {
-                    ComplianceToggleGroup(complianceData: .wcag(wcag), theme: .contrast)
-                        .padding(20.0)
-                        .frame(maxWidth: width, maxHeight: .infinity, alignment: .leading)
+                    ScaleToFitWidth {
+                        ComplianceToggleGroup(complianceData: .wcag(wcag), theme: .contrast)
+                            .padding(20.0)
+                    }
+                    .frame(maxWidth: width, maxHeight: .infinity, alignment: .leading)
                 }
             )
             .buttonStyle(AppearanceButtonStyle(
@@ -54,9 +91,11 @@ struct CompliancePreviewAPCA: View {
             title: PikaText.textAppearanceAPCATitle,
             description: PikaText.textAppearanceAPCADescription
         ) {
-            ComplianceToggleGroup(complianceData: .apca(apca), theme: .weight)
-                .padding(20.0)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            ScaleToFitWidth(alignment: .center) {
+                ComplianceToggleGroup(complianceData: .apca(apca), theme: .weight)
+                    .padding(20.0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 }
@@ -94,7 +133,11 @@ struct CompliancePreviewBoth: View {
     @ViewBuilder
     private func footerPreview(wcag: NSColor.WCAG, apca: NSColor.APCA, theme: ComplianceToggleGroup.Themes) -> some View {
         GeometryReader { geometry in
-            let scale = min(1.0, geometry.size.width / 380)
+            // Lay the row out at its full natural width so the Spacer-aligned badges keep
+            // their real size, then scale the whole thing down to the tile — otherwise the
+            // badges compress and truncate at the tile width before the scale is applied.
+            let reference: CGFloat = 430
+            let scale = min(1.0, geometry.size.width / reference)
 
             VStack(alignment: .leading, spacing: 4.0) {
                 HStack(spacing: 0) {
@@ -130,8 +173,9 @@ struct CompliancePreviewBoth: View {
                 }
             }
             .padding(.horizontal, 10.0)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .frame(width: reference, alignment: .leading)
             .scaleEffect(scale, anchor: .leading)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         }
     }
 }

--- a/Pika/Views/ComplianceToggle.swift
+++ b/Pika/Views/ComplianceToggle.swift
@@ -12,8 +12,12 @@ struct ComplianceToggle: View {
         HStack(alignment: .center, spacing: 2.0) {
             IconImage(name: isCompliant ? "checkmark.circle.fill" : "xmark.circle", resizable: true)
                 .frame(width: size == .small ? 13.0 : 14.0, height: size == .small ? 13.0 : 14.0)
+                .layoutPriority(1)
+            // Truncate (e.g. "Bo…") when the footer is too narrow to fit the full label,
+            // rather than clipping. Full size otherwise.
             Text(title)
-                .fixedSize()
+                .lineLimit(1)
+                .truncationMode(.tail)
 
             if combined {
                 if large {
@@ -43,7 +47,6 @@ struct ComplianceToggle: View {
         .foregroundStyle(isCompliant ? .primary
             : .secondary)
         .help(tooltip)
-        .fixedSize()
     }
 }
 

--- a/Pika/Views/ContentView.swift
+++ b/Pika/Views/ContentView.swift
@@ -98,7 +98,13 @@ struct ContentView: View {
             // clips. ANDed with user preferences below so the saved toggles survive
             // resizing (suppress-but-remember).
             let allowPreview = height >= PikaAdaptiveHeight.preview && width >= PikaAdaptiveWidth.preview
-            let allowContrast = height >= PikaAdaptiveHeight.contrast && width >= PikaAdaptiveWidth.contrast
+            // The contrast footer clings on far longer than the other elements. On height it
+            // stays until the window is short enough that the expand affordance tucks into
+            // the corner; on width it never hides outright — instead the WCAG/APCA rows drop
+            // just their right-hand compliance badges, keeping the left-most ratio value.
+            let allowContrastHeight = height >= PikaAdaptiveHeight.expandCornerBelow
+            let allowContrastWidth = width >= PikaAdaptiveWidth.contrast
+            let allowContrast = allowContrastHeight && allowContrastWidth
             let allowPalettes = height >= PikaAdaptiveHeight.palettes && width >= PikaAdaptiveWidth.palettes
             // The preview pill overlaps the type labels, so labels only show when the
             // pill is effectively hidden.
@@ -109,9 +115,9 @@ struct ContentView: View {
             let suppressed = (showColorPreview && !allowPreview)
                 || (showCompliance && !allowContrast)
                 || (historyDrawerVisible && !allowPalettes)
-            // Centre the affordance normally, but at very short heights tuck it into the
-            // top-right corner so it doesn't sit on top of the colour values.
-            let expandAlignment: Alignment = height < PikaAdaptiveHeight.expandCornerBelow ? .topTrailing : .center
+            // Always tuck the expand affordance into the top-right corner so it never sits
+            // on top of the colour values.
+            let expandAlignment: Alignment = .topTrailing
 
             VStack(alignment: .trailing, spacing: 0) {
                 Divider()
@@ -169,11 +175,17 @@ struct ContentView: View {
                         swapTimerSubscription = swapTimer.connect()
                     }
 
-                if showCompliance, allowContrast {
+                if showCompliance, allowContrastHeight {
                     AdaptiveDivider()
                     // Slide only — no opacity fade, so the footer is always full opacity.
-                    Footer(foreground: eyedroppers.foreground, background: eyedroppers.background)
-                        .transition(.move(edge: .bottom))
+                    // `showsCompliance` drops the right-hand badges when there isn't the
+                    // width for them, so the footer stays put and only sheds on height.
+                    Footer(
+                        foreground: eyedroppers.foreground,
+                        background: eyedroppers.background,
+                        showsCompliance: allowContrastWidth
+                    )
+                    .transition(.move(edge: .bottom))
                 }
                 if historyDrawerVisible, allowPalettes {
                     ColorHistoryDrawer(foreground: eyedroppers.foreground, background: eyedroppers.background)
@@ -196,7 +208,8 @@ struct ContentView: View {
                 case .ended: isHovering = false
                 }
             }
-            .animation(.easeInOut(duration: 0.2), value: allowContrast)
+            .animation(.easeInOut(duration: 0.2), value: allowContrastHeight)
+            .animation(.easeInOut(duration: 0.2), value: allowContrastWidth)
             .animation(.easeInOut(duration: 0.2), value: allowPalettes)
             .animation(.easeInOut(duration: 0.15), value: suppressed)
             .animation(.easeInOut(duration: 0.15), value: isHovering)

--- a/Pika/Views/ContentView.swift
+++ b/Pika/Views/ContentView.swift
@@ -5,8 +5,10 @@ import UniformTypeIdentifiers
 
 /// Height thresholds (in points of available window content height) below which each
 /// element is shed, so the window can shrink far smaller than the sum of everything.
-/// Ordered largest-first to match the shed order: palettes drop first, type labels last.
-/// These are the tuning knobs for the adaptive layout.
+/// Ordered largest-first to match the shed order: palettes drop first, then contrast,
+/// preview, and colour names. Type labels are the last to go, but they hide only via the
+/// preview-pill overlap — the window floor (160) sits above any useful height threshold
+/// for them. These are the tuning knobs for the adaptive layout.
 enum PikaAdaptiveHeight {
     static let floor: CGFloat = 160 // bare minimum content height (matches window frame min ≈ 200pt window)
     static let expandCornerBelow: CGFloat = 200 // below this content height (~240pt window) the button tucks top-right
@@ -14,7 +16,6 @@ enum PikaAdaptiveHeight {
     static let contrast: CGFloat = 250 // compliance footer (~50pt)
     static let preview: CGFloat = 200 // preview pill
     static let colorNames: CGFloat = 175 // CSS colour name under each value
-    static let typeLabels: CGFloat = 150 // "Foreground"/"Background" labels
 }
 
 /// Width thresholds below which horizontally-laid-out elements are shed rather than left
@@ -181,7 +182,9 @@ struct ContentView: View {
             }
             .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
             .environment(\.pikaAdaptiveVisibility, PikaAdaptiveVisibility(
-                showsTypeLabels: height >= PikaAdaptiveHeight.typeLabels && !previewVisible,
+                // Type labels sit behind the preview pill, so they hide only when it shows
+                // — the window floor keeps height above any threshold that would drop them.
+                showsTypeLabels: !previewVisible,
                 showsColorNames: height >= PikaAdaptiveHeight.colorNames
             ))
             // Continuous hover is stable when the button appears under the cursor —

--- a/Pika/Views/ContentView.swift
+++ b/Pika/Views/ContentView.swift
@@ -3,6 +3,51 @@ import Defaults
 import SwiftUI
 import UniformTypeIdentifiers
 
+/// Height thresholds (in points of available window content height) below which each
+/// element is shed, so the window can shrink far smaller than the sum of everything.
+/// Ordered largest-first to match the shed order: palettes drop first, type labels last.
+/// These are the tuning knobs for the adaptive layout.
+enum PikaAdaptiveHeight {
+    static let floor: CGFloat = 160 // bare minimum content height (matches window frame min ≈ 200pt window)
+    static let expandCornerBelow: CGFloat = 200 // below this content height (~240pt window) the button tucks top-right
+    static let palettes: CGFloat = 300 // history drawer (~74pt)
+    static let contrast: CGFloat = 250 // compliance footer (~50pt)
+    static let preview: CGFloat = 200 // preview pill
+    static let colorNames: CGFloat = 175 // CSS colour name under each value
+    static let typeLabels: CGFloat = 150 // "Foreground"/"Background" labels
+}
+
+/// Width thresholds below which horizontally-laid-out elements are shed rather than left
+/// to clip past the window edge. The footer's contrast panels are the widest content.
+enum PikaAdaptiveWidth {
+    static let base: CGFloat = 360 // bare minimum content width (matches window frame min)
+    // Footer (with its shortened labels) and the palette drawer share one hide width so
+    // they appear/disappear together — different values read as a bug.
+    static let palettes: CGFloat = 460
+    static let contrast: CGFloat = 460
+    static let preview: CGFloat = 420 // preview pill
+}
+
+/// Size-driven visibility for elements inside the eyedropper rows, threaded down to
+/// the deeply-nested `EyedropperButton` via the environment. `true` means "there is
+/// room" — it's ANDed with the user's own preference at the point of use, so a saved
+/// setting is never mutated (suppress-but-remember).
+struct PikaAdaptiveVisibility: Equatable {
+    var showsTypeLabels: Bool = true
+    var showsColorNames: Bool = true
+}
+
+private struct PikaAdaptiveVisibilityKey: EnvironmentKey {
+    static let defaultValue = PikaAdaptiveVisibility()
+}
+
+extension EnvironmentValues {
+    var pikaAdaptiveVisibility: PikaAdaptiveVisibility {
+        get { self[PikaAdaptiveVisibilityKey.self] }
+        set { self[PikaAdaptiveVisibilityKey.self] = newValue }
+    }
+}
+
 struct ContentView: View {
     @EnvironmentObject var eyedroppers: Eyedroppers
 
@@ -20,59 +65,137 @@ struct ContentView: View {
     @State var swapVisible: Bool = false
     @State private var swapTimerSubscription: Cancellable?
     @State private var swapTimer = Timer.publish(every: 0.25, on: .main, in: .common)
+    @State private var isHovering: Bool = false
+
+    /// Content size that comfortably shows every element the user currently has enabled —
+    /// the target for the "expand to fit" control. Takes the largest width/height each
+    /// enabled element needs, plus a small margin so it lands just past each threshold.
+    private func expandTargetSize() -> CGSize {
+        let margin: CGFloat = 8
+        var width = PikaAdaptiveWidth.base
+        var height = PikaAdaptiveHeight.floor
+        if showColorPreview {
+            width = max(width, PikaAdaptiveWidth.preview)
+            height = max(height, PikaAdaptiveHeight.preview)
+        }
+        if showCompliance {
+            width = max(width, PikaAdaptiveWidth.contrast)
+            height = max(height, PikaAdaptiveHeight.contrast)
+        }
+        if historyDrawerVisible {
+            width = max(width, PikaAdaptiveWidth.palettes)
+            height = max(height, PikaAdaptiveHeight.palettes)
+        }
+        return CGSize(width: width + margin, height: height + margin)
+    }
 
     var body: some View {
-        VStack(alignment: .trailing, spacing: 0) {
-            Divider()
-            ColorPickers()
-                .onHover { hover in
-                    guard hover else { return }
-                    swapVisible = true
-                    swapTimerSubscription?.cancel()
-                    swapTimerSubscription = nil
-                }
-                .onReceive(swapTimer) { _ in
-                    swapVisible = false
-                    swapTimerSubscription?.cancel()
-                    swapTimerSubscription = nil
-                }
-                .overlay(
-                    SwapPreviewButton(
-                        foreground: eyedroppers.foreground,
-                        background: eyedroppers.background,
-                        showPreview: showColorPreview,
-                        isVisible: swapVisible,
-                        onSwap: {
-                            NSApp.sendAction(#selector(AppDelegate.triggerSwap), to: nil, from: nil)
-                        }
-                    )
-                    .onReceive(NotificationCenter.default.publisher(for: .triggerSwap)) { _ in
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            eyedroppers.swap()
-                        }
-                    }
-                    .focusable(false)
-                    .padding(.horizontal, 16.0)
-                    .padding(.top, appMode.usesPopover ? 42.0 : 16.0)
-                    .frame(maxHeight: .infinity, alignment: .top)
-                )
-                .onHover { hover in
-                    guard !hover, swapTimerSubscription == nil else {
-                        return
-                    }
-                    swapTimer = Timer.publish(every: 0.25, on: .main, in: .common)
-                    swapTimerSubscription = swapTimer.connect()
-                }
+        GeometryReader { geo in
+            let height = geo.size.height
+            let width = geo.size.width
+            // Room-for flags: an element needs both enough height AND enough width, or it
+            // clips. ANDed with user preferences below so the saved toggles survive
+            // resizing (suppress-but-remember).
+            let allowPreview = height >= PikaAdaptiveHeight.preview && width >= PikaAdaptiveWidth.preview
+            let allowContrast = height >= PikaAdaptiveHeight.contrast && width >= PikaAdaptiveWidth.contrast
+            let allowPalettes = height >= PikaAdaptiveHeight.palettes && width >= PikaAdaptiveWidth.palettes
+            // The preview pill overlaps the type labels, so labels only show when the
+            // pill is effectively hidden.
+            let previewVisible = showColorPreview && allowPreview
 
-            if showCompliance {
+            // An enabled element we're hiding purely for space. When any exist, offer to
+            // grow the window back to a size that fits everything the user has turned on.
+            let suppressed = (showColorPreview && !allowPreview)
+                || (showCompliance && !allowContrast)
+                || (historyDrawerVisible && !allowPalettes)
+            // Centre the affordance normally, but at very short heights tuck it into the
+            // top-right corner so it doesn't sit on top of the colour values.
+            let expandAlignment: Alignment = height < PikaAdaptiveHeight.expandCornerBelow ? .topTrailing : .center
+
+            VStack(alignment: .trailing, spacing: 0) {
                 Divider()
-                Footer(foreground: eyedroppers.foreground, background: eyedroppers.background)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                ColorPickers()
+                    .onHover { hover in
+                        guard hover else { return }
+                        swapVisible = true
+                        swapTimerSubscription?.cancel()
+                        swapTimerSubscription = nil
+                    }
+                    .onReceive(swapTimer) { _ in
+                        swapVisible = false
+                        swapTimerSubscription?.cancel()
+                        swapTimerSubscription = nil
+                    }
+                    .overlay(
+                        SwapPreviewButton(
+                            foreground: eyedroppers.foreground,
+                            background: eyedroppers.background,
+                            showPreview: previewVisible,
+                            isVisible: swapVisible,
+                            onSwap: {
+                                NSApp.sendAction(#selector(AppDelegate.triggerSwap), to: nil, from: nil)
+                            }
+                        )
+                        .onReceive(NotificationCenter.default.publisher(for: .triggerSwap)) { _ in
+                            withAnimation(.easeInOut(duration: 0.2)) {
+                                eyedroppers.swap()
+                            }
+                        }
+                        .focusable(false)
+                        .padding(.horizontal, 16.0)
+                        .padding(.top, appMode.usesPopover ? 42.0 : 16.0)
+                        .frame(maxHeight: .infinity, alignment: .top)
+                    )
+                    // Expand-to-fit sits over the colour tiles (not the whole app), so it
+                    // centres on the swatches rather than drifting down over the footer.
+                    .overlay(alignment: expandAlignment) {
+                        if suppressed, isHovering {
+                            ExpandToFitButton {
+                                NotificationCenter.default.post(
+                                    name: .expandToFit,
+                                    object: NSValue(size: expandTargetSize())
+                                )
+                            }
+                            .padding(expandAlignment == .topTrailing ? 8 : 0)
+                            .transition(.scale(scale: 0.9).combined(with: .opacity))
+                        }
+                    }
+                    .onHover { hover in
+                        guard !hover, swapTimerSubscription == nil else {
+                            return
+                        }
+                        swapTimer = Timer.publish(every: 0.25, on: .main, in: .common)
+                        swapTimerSubscription = swapTimer.connect()
+                    }
+
+                if showCompliance, allowContrast {
+                    AdaptiveDivider()
+                    Footer(foreground: eyedroppers.foreground, background: eyedroppers.background)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+                if historyDrawerVisible, allowPalettes {
+                    ColorHistoryDrawer(foreground: eyedroppers.foreground, background: eyedroppers.background)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
-            if historyDrawerVisible {
-                ColorHistoryDrawer(foreground: eyedroppers.foreground, background: eyedroppers.background)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
+            .environment(\.pikaAdaptiveVisibility, PikaAdaptiveVisibility(
+                showsTypeLabels: height >= PikaAdaptiveHeight.typeLabels && !previewVisible,
+                showsColorNames: height >= PikaAdaptiveHeight.colorNames
+            ))
+            // Continuous hover is stable when the button appears under the cursor —
+            // plain `.onHover` re-fires enter/exit as the overlay mounts, which flickers
+            // the button (and re-wraps the value text) in a loop.
+            .onContinuousHover { phase in
+                switch phase {
+                case .active: isHovering = true
+                case .ended: isHovering = false
+                }
             }
+            .animation(.easeInOut(duration: 0.2), value: allowContrast)
+            .animation(.easeInOut(duration: 0.2), value: allowPalettes)
+            .animation(.easeInOut(duration: 0.15), value: suppressed)
+            .animation(.easeInOut(duration: 0.15), value: isHovering)
         }
         .onAppear {
             if Defaults[.palettes].first?.pairs.isEmpty ?? true {
@@ -165,6 +288,69 @@ struct ContentView: View {
                 }
             }
         }
+    }
+}
+
+/// Shared surface for the footer and palette drawer. In light mode the under-window
+/// vibrancy material washes out to near-nothing, so use the standard window background
+/// for a clearly-defined panel; dark mode keeps the material, which reads well there.
+struct AdaptivePanelBackground: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        if colorScheme == .dark {
+            VisualEffect(
+                material: NSVisualEffectView.Material.underWindowBackground,
+                blendingMode: NSVisualEffectView.BlendingMode.behindWindow
+            )
+        } else {
+            Color(NSColor.windowBackgroundColor)
+        }
+    }
+}
+
+/// Divider that reads as a recessed seam in both appearances. The system `Divider`
+/// renders too light over the footer/drawer materials in light mode (looks white rather
+/// than a darker separator), so tint explicitly with `primary`, which flips per scheme.
+struct AdaptiveDivider: View {
+    @Environment(\.colorScheme) private var colorScheme
+    var axis: Axis = .horizontal
+
+    var body: some View {
+        Rectangle()
+            .fill(colorScheme == .dark ? Color.white.opacity(0.14) : Color.black.opacity(0.24))
+            .frame(
+                width: axis == .vertical ? 1 : nil,
+                height: axis == .horizontal ? 1 : nil
+            )
+    }
+}
+
+/// Small floating capsule shown when the adaptive layout is hiding enabled elements.
+/// Tapping it grows the window just enough to reveal them again.
+private struct ExpandToFitButton: View {
+    let action: () -> Void
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 5.0) {
+                Image(systemName: "arrow.up.left.and.arrow.down.right")
+                    .font(.system(size: 10, weight: .semibold))
+                Text(PikaText.textExpandToFit)
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .padding(.horizontal, 10.0)
+            .padding(.vertical, 5.0)
+            .background(.regularMaterial, in: Capsule())
+            .overlay(Capsule().strokeBorder(Color.primary.opacity(0.12)))
+            .opacity(hovering ? 1.0 : 0.9)
+            .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 1)
+        }
+        .buttonStyle(.plain)
+        .focusable(false)
+        .onHover { hovering = $0 }
+        .help(PikaText.textExpandToFit)
     }
 }
 

--- a/Pika/Views/ContentView.swift
+++ b/Pika/Views/ContentView.swift
@@ -23,8 +23,8 @@ enum PikaAdaptiveWidth {
     static let base: CGFloat = 360 // bare minimum content width (matches window frame min)
     // Footer (with its shortened labels) and the palette drawer share one hide width so
     // they appear/disappear together — different values read as a bug.
-    static let palettes: CGFloat = 460
-    static let contrast: CGFloat = 460
+    static let palettes: CGFloat = 410
+    static let contrast: CGFloat = 410
     static let preview: CGFloat = 420 // preview pill
 }
 
@@ -170,8 +170,9 @@ struct ContentView: View {
 
                 if showCompliance, allowContrast {
                     AdaptiveDivider()
+                    // Slide only — no opacity fade, so the footer is always full opacity.
                     Footer(foreground: eyedroppers.foreground, background: eyedroppers.background)
-                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .transition(.move(edge: .bottom))
                 }
                 if historyDrawerVisible, allowPalettes {
                     ColorHistoryDrawer(foreground: eyedroppers.foreground, background: eyedroppers.background)

--- a/Pika/Views/EyedropperButton.swift
+++ b/Pika/Views/EyedropperButton.swift
@@ -1,6 +1,50 @@
 import Defaults
 import SwiftUI
 
+private struct ValueWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
+
+/// The colour value, shrunk to fit two lines as its column narrows. The font size is
+/// computed deterministically from the (font-independent) column width, so — unlike
+/// `minimumScaleFactor` + `lineLimit` — the wrap can't oscillate between one and two
+/// lines during a resize.
+struct AdaptiveValueText: View {
+    let value: String
+    let color: Color
+    private let baseSize: CGFloat = 18
+    private let minSize: CGFloat = 11
+    @State private var width: CGFloat = 0
+
+    private var fontSize: CGFloat {
+        guard width > 4 else { return baseSize }
+        let full = (value as NSString).size(withAttributes: [.font: NSFont.systemFont(ofSize: baseSize)]).width
+        guard full > 0 else { return baseSize }
+        // Scale the font *proportionally* with the column width so the wrap point stays
+        // put as the window resizes — no bistable jumping. The 1.5 factor (vs a
+        // theoretical 2 for two full lines) leaves slack for word-boundary wrapping, so
+        // long values still fit two lines instead of spilling to a truncated third.
+        let scale = min(1, (1.5 * width) / full)
+        return max(minSize, baseSize * scale)
+    }
+
+    var body: some View {
+        Text(value)
+            .foregroundStyle(color)
+            .font(.system(size: fontSize, weight: .regular))
+            .lineLimit(2)
+            .truncationMode(.tail)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                GeometryReader { geo in
+                    Color.clear.preference(key: ValueWidthKey.self, value: geo.size.width)
+                }
+            )
+            .onPreferenceChange(ValueWidthKey.self) { width = $0 }
+    }
+}
+
 struct EyedropperButton: View {
     @ObservedObject var eyedropper: Eyedropper
     @Default(.colorFormat) var colorFormat
@@ -38,21 +82,15 @@ struct EyedropperButton: View {
                             )
 
                         VStack(alignment: .leading, spacing: 6.0) {
-                            Text((eyedropper.color.usingColorSpace(colorSpace) ?? eyedropper.color).toFormat(format: colorFormat, style: copyFormat))
-                                .foregroundStyle(eyedropper.color.getUIColor())
-                                .font(.system(size: 18, weight: .regular))
-                                // Shrink long formats (OKLCH/RGB) to stay within two
-                                // lines as the window narrows, rather than wrapping to
-                                // three lines or clipping. The trailing padding keeps the
-                                // text clear of the copy / system-picker hover buttons.
-                                .lineLimit(2)
-                                .minimumScaleFactor(0.5)
-                                // Bound the text to the column width (minus the button
-                                // gutter) so it wraps/scales inside its column instead of
-                                // reporting its single-line ideal width and overflowing
-                                // past the window edge.
-                                .padding(.trailing, 32.0)
-                                .frame(maxWidth: .infinity, alignment: .leading)
+                            // Trailing gutter keeps the value clear of the copy /
+                            // system-picker hover buttons; the value itself shrinks to fit
+                            // two lines (see AdaptiveValueText).
+                            AdaptiveValueText(
+                                value: (eyedropper.color.usingColorSpace(colorSpace) ?? eyedropper.color)
+                                    .toFormat(format: colorFormat, style: copyFormat),
+                                color: Color(eyedropper.color.getUIColor())
+                            )
+                            .padding(.trailing, 32.0)
 
                             if !hideColorNames, adaptive.showsColorNames {
                                 Text(eyedropper.getClosestColor())

--- a/Pika/Views/EyedropperButton.swift
+++ b/Pika/Views/EyedropperButton.swift
@@ -7,6 +7,7 @@ struct EyedropperButton: View {
     @Default(.copyFormat) var copyFormat
     @Default(.hideColorNames) var hideColorNames
     @Default(.showColorPreview) var showColorPreview
+    @Environment(\.pikaAdaptiveVisibility) var adaptive
 
     @State var hoverVisible: Bool = false
     @State private var colorSpace = Defaults[.colorSpace]
@@ -20,25 +21,40 @@ struct EyedropperButton: View {
             }, label: {
                 ZStack {
                     VStack(alignment: .leading, spacing: 2.0) {
+                        // Visibility is size-aware (`adaptive.showsTypeLabels` already
+                        // folds in the preview-pill overlap) so labels fade out as the
+                        // window shrinks and return when it grows again.
+                        let showsTypeLabel = adaptive.showsTypeLabels
                         Text(eyedropper.type.description)
                             .font(.caption)
                             .fontWeight(.semibold)
                             .foregroundStyle(eyedropper.color.getUIColor().opacity(0.75))
-                            .opacity(showColorPreview ? 0 : 1)
+                            .opacity(showsTypeLabel ? 1 : 0)
                             .animation(
-                                showColorPreview
-                                    ? .easeInOut(duration: 0.2)
-                                    : .easeInOut(duration: 0.25).delay(0.3),
-                                value: showColorPreview
+                                showsTypeLabel
+                                    ? .easeInOut(duration: 0.25).delay(0.3)
+                                    : .easeInOut(duration: 0.2),
+                                value: showsTypeLabel
                             )
 
                         VStack(alignment: .leading, spacing: 6.0) {
                             Text((eyedropper.color.usingColorSpace(colorSpace) ?? eyedropper.color).toFormat(format: colorFormat, style: copyFormat))
                                 .foregroundStyle(eyedropper.color.getUIColor())
                                 .font(.system(size: 18, weight: .regular))
+                                // Shrink long formats (OKLCH/RGB) to stay within two
+                                // lines as the window narrows, rather than wrapping to
+                                // three lines or clipping. The trailing padding keeps the
+                                // text clear of the copy / system-picker hover buttons.
+                                .lineLimit(2)
+                                .minimumScaleFactor(0.5)
+                                // Bound the text to the column width (minus the button
+                                // gutter) so it wraps/scales inside its column instead of
+                                // reporting its single-line ideal width and overflowing
+                                // past the window edge.
                                 .padding(.trailing, 32.0)
+                                .frame(maxWidth: .infinity, alignment: .leading)
 
-                            if !hideColorNames {
+                            if !hideColorNames, adaptive.showsColorNames {
                                 Text(eyedropper.getClosestColor())
                                     .font(.system(size: 12, weight: .medium))
                                     .foregroundStyle(eyedropper.color.getUIColor())

--- a/Pika/Views/Footer.swift
+++ b/Pika/Views/Footer.swift
@@ -65,7 +65,7 @@ private struct FooterRow: View {
                 }
             }
 
-            Divider()
+            AdaptiveDivider(axis: .vertical)
 
             VStack(alignment: .leading, spacing: 3.0) {
                 Text(complianceLabel)
@@ -152,7 +152,7 @@ private struct CompactBothFooter: View {
                 }
             }
 
-            Divider()
+            AdaptiveDivider()
                 .padding(.horizontal, -12.0)
 
             HStack(spacing: 6.0) {
@@ -207,10 +207,7 @@ struct Footer: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 12.0)
-        .background(VisualEffect(
-            material: NSVisualEffectView.Material.underWindowBackground,
-            blendingMode: NSVisualEffectView.BlendingMode.behindWindow
-        ))
+        .background(AdaptivePanelBackground())
     }
 }
 

--- a/Pika/Views/Footer.swift
+++ b/Pika/Views/Footer.swift
@@ -11,6 +11,9 @@ private struct FooterRow: View {
     @ObservedObject var foreground: Eyedropper
     @ObservedObject var background: Eyedropper
     var combineCompliance: Bool
+    /// When false there isn't the width for the compliance badges, so the whole right-hand
+    /// side (divider + toggle group) drops and only the left-most ratio value remains.
+    var showsCompliance: Bool = true
 
     private var contrastHeader: String {
         kind == .wcag ? PikaText.textColorRatio : PikaText.textLightnessContrastValue
@@ -65,18 +68,20 @@ private struct FooterRow: View {
                 }
             }
 
-            AdaptiveDivider(axis: .vertical)
+            if showsCompliance {
+                AdaptiveDivider(axis: .vertical)
 
-            VStack(alignment: .leading, spacing: 3.0) {
-                Text(complianceLabel)
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.secondary)
+                VStack(alignment: .leading, spacing: 3.0) {
+                    Text(complianceLabel)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(.secondary)
 
-                ComplianceToggleGroup(
-                    complianceData: complianceData,
-                    theme: combineCompliance ? .contrast : .weight
-                )
+                    ComplianceToggleGroup(
+                        complianceData: complianceData,
+                        theme: combineCompliance ? .contrast : .weight
+                    )
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -186,6 +191,9 @@ struct Footer: View {
     @Default(.contrastStandard) var contrastStandard
     @ObservedObject var foreground: Eyedropper
     @ObservedObject var background: Eyedropper
+    /// Whether there's width for the compliance badges. WCAG/APCA drop the badges entirely
+    /// when there isn't; the denser "both" view instead clips its right edge (below).
+    var showsCompliance: Bool = true
 
     var body: some View {
         Group {
@@ -200,13 +208,19 @@ struct Footer: View {
                     kind: contrastStandard == .wcag ? .wcag : .apca,
                     foreground: foreground,
                     background: background,
-                    combineCompliance: combineCompliance
+                    combineCompliance: combineCompliance,
+                    showsCompliance: showsCompliance
                 )
                 .frame(maxHeight: 50.0)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 12.0)
+        // Only the dense "both" view can overflow (its badges pack right against a Spacer);
+        // when narrow they spill past the edge and clip rather than compressing the value.
+        // WCAG/APCA instead drop their badges outright (see `showsCompliance`), so nothing
+        // there overflows and the clip is a harmless no-op for them.
+        .clipped()
         .background(AdaptivePanelBackground())
     }
 }

--- a/Pika/Views/HelpData.swift
+++ b/Pika/Views/HelpData.swift
@@ -47,6 +47,8 @@ let urlGroups: [URLGroup] = [
         ("pika://pick/foreground", PikaText.textPickForeground),
         ("pika://pick/background", PikaText.textPickBackground),
         ("pika://pick/contrast", PikaText.textPickContrast),
+        ("pika://pick/foreground/<format>", PikaText.textUrlPickForegroundFormat),
+        ("pika://pick/background/<format>", PikaText.textUrlPickBackgroundFormat),
     ]),
     (PikaText.textColorSystemPicker, [
         ("pika://system/foreground", PikaText.textColorSystemPickerForegroundSimple),
@@ -55,6 +57,8 @@ let urlGroups: [URLGroup] = [
     (PikaText.textUrlGroupCopy, [
         ("pika://copy/foreground", PikaText.textCopyForeground),
         ("pika://copy/background", PikaText.textCopyBackground),
+        ("pika://copy/foreground/<format>", PikaText.textUrlCopyForegroundFormat),
+        ("pika://copy/background/<format>", PikaText.textUrlCopyBackgroundFormat),
         ("pika://copy/text", PikaText.textMenuCopyAllAsText),
         ("pika://copy/json", PikaText.textMenuCopyAllAsJSON),
     ]),

--- a/Pika/Views/PreferencesView.swift
+++ b/Pika/Views/PreferencesView.swift
@@ -12,6 +12,7 @@ private struct GeneralAndSelectionSection: View {
         @Default(.betaUpdates) var betaUpdates
     #endif
     @Default(.hidePikaWhilePicking) var hidePikaWhilePicking
+    @Default(.windowShadow) var windowShadow
     @Default(.pickContrastingColor) var pickContrastingColor
     @Default(.appMode) var appMode
     @Default(.appFloating) var appFloating
@@ -52,6 +53,18 @@ private struct GeneralAndSelectionSection: View {
                         Text(PikaText.textIconDescription)
                     }
                 }
+
+                Text(PikaText.textWindowSettingsTitle)
+                    .font(.system(size: 16))
+                    .padding(.top, 8.0)
+                Picker("", selection: $windowShadow) {
+                    ForEach(WindowShadow.allCases, id: \.self) { value in
+                        Text(value.localizedString())
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .fixedSize()
             }
             .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
             .padding(.all, 24.0)

--- a/Pika/Views/Visualisation.swift
+++ b/Pika/Views/Visualisation.swift
@@ -1,11 +1,30 @@
 import MetalKit
 import SwiftUI
 
+/// Reports the hosting `NSWindow` up to SwiftUI so notification handlers can tell this
+/// window's events apart from those of transient popups (e.g. a Picker's menu window).
+private struct WindowAccessor: NSViewRepresentable {
+    @Binding var window: NSWindow?
+
+    func makeNSView(context _: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async { window = view.window }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context _: Context) {
+        DispatchQueue.main.async {
+            if window == nil { window = nsView.window }
+        }
+    }
+}
+
 struct Visualisation: View {
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     var device: MTLDevice!
     @State var isShown = false
     @State var renderID = UUID()
+    @State private var hostWindow: NSWindow?
 
     init() {
         guard let device = MTLCreateSystemDefaultDevice() else {
@@ -34,24 +53,36 @@ struct Visualisation: View {
                 }
             }
         }
+        .background(WindowAccessor(window: $hostWindow))
         .animation(.easeIn(duration: 0.8), value: isShown)
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 isShown = true
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
+        // Only react to this view's own window. Otherwise a transient popup — like the
+        // menu window a Picker opens — fires willClose/didBecomeKey and wrongly toggles
+        // the shader (which made the header animation vanish when changing a dropdown).
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { note in
+            guard isHostWindow(note) else { return }
             if !isShown {
                 renderID = UUID()
                 isShown = true
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didMiniaturizeNotification)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didMiniaturizeNotification)) { note in
+            guard isHostWindow(note) else { return }
             isShown = false
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { _ in
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { note in
+            guard isHostWindow(note) else { return }
             isShown = false
         }
+    }
+
+    private func isHostWindow(_ note: Notification) -> Bool {
+        guard let hostWindow else { return false }
+        return (note.object as? NSWindow) === hostWindow
     }
 }
 


### PR DESCRIPTION
Brings the 1.9.0 work into `main`. This release resolves #238 — the window shadow influencing colour readings, and the minimum window size being larger than necessary — plus related polish. (Merged into `1.9.0` via #240.)

## Window shadow
- New **Window Settings** section in Preferences with a shadow dropdown: **Show shadow** / **Hide shadow while picking** / **Hide shadow**.
- "Hide shadow while picking" drops the shadow only during a pick (chained foreground→background handled cleanly).
- Shadowless windows get a **hairline border** via a borderless, click-through companion window so the edge stays defined.

## Adaptive sizing
- Lower window minimum (~200pt tall, 360 wide); UI sheds as the window shrinks — palettes → contrast footer → preview pill → colour names → type labels — via height/width breakpoints, suppress-but-remember.
- Footer and palette drawer share one hide width; compliance badge titles truncate gracefully when tight.
- Colour value **shrinks to fit two lines** via proportional font scaling — smooth on resize, no flicker, no truncation.
- Floating **expand-to-fit** control (hover-gated) that grows the window to reveal hidden-but-enabled elements.

## Polish
- Shorter footer labels ("Contrast", "Contrast (Lc)", "Body").
- Standard window-background panels in light mode; `AdaptiveDivider` for consistent seams; removed the divider between the two swatches.
- Fixed the Preferences header shader vanishing when a Picker menu closed.

## Before release
- New preference/UI strings are English-only with English fallbacks in the other locales — they need real translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)