### PR TITLE
Translate new 1.9.0 window-shadow strings

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -63,6 +63,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Surface the full run output so a failing tag-mode run reports the
+          # actual API error instead of an opaque "is_error" with no detail.
+          # Matches the reusable review workflow, which is debuggable for this
+          # exact reason.
+          show_full_output: true
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,15 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Serialise runs per issue/PR so rapid-fire @claude comments don't spawn
+# concurrent runs that race on context assembly (which yields an empty
+# formatted_context and an immediate is_error failure). Unlike the review
+# workflow we don't cancel in-progress runs — each @claude request is distinct
+# and worth completing.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   claude:
     if: |

--- a/Pika/Assets/de.lproj/Localizable.strings
+++ b/Pika/Assets/de.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "Beide";
 
 /* Contrast ratio */
-"color.ratio" = "Kontrastverhältnis";
+"color.ratio" = "Kontrast";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "Das Kontrastverhältnis ist ein Maß für den wahrgenommenen Helligkeitsunterschied zwischen zwei Farben, mit dem das Kontrastverhältnis berechnet wird.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Kontrastwert (Lc)";
+"color.lc" = "Kontrast (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "Der Helligkeitskontrast (Lc) ist ein Maß für den Helligkeitsunterschied zwischen zwei Farben, mit dem der Kontrastwert berechnet wird.";

--- a/Pika/Assets/de.lproj/Localizable.strings
+++ b/Pika/Assets/de.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "Vordergrund und Hintergrund auswählen";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "Fensterschatten";
+"preferences.shadow.options.always" = "Schatten anzeigen";
+"preferences.shadow.options.hiddenWhilePicking" = "Schatten während dem Auswählen verstecken";
+"preferences.shadow.options.never" = "Schatten verstecken";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "Zum Anpassen vergrößern";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "Fenstereinstellungen";

--- a/Pika/Assets/es.lproj/Localizable.strings
+++ b/Pika/Assets/es.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "Seleccionar primer plano y segundo plano";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "Sombra de la ventana";
+"preferences.shadow.options.always" = "Mostrar sombra";
+"preferences.shadow.options.hiddenWhilePicking" = "Ocultar sombra durante la selección";
+"preferences.shadow.options.never" = "Ocultar sombra";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "Expandir para ajustar";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "Ajustes de Ventana";

--- a/Pika/Assets/es.lproj/Localizable.strings
+++ b/Pika/Assets/es.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "Ambos";
 
 /* Contrast ratio */
-"color.ratio" = "Proporción de contraste";
+"color.ratio" = "Contraste";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "La proporción de contraste es una medida de la diferencia en el brillo percibido entre dos colores, utilizada para calcular la proporción de contraste.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Valor de Contraste (Lc)";
+"color.lc" = "Contraste (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "El contraste de luminosidad (Lc) es una medida de la diferencia de luminosidad entre dos colores, utilizada para calcular el valor de contraste.";
@@ -212,7 +212,7 @@
 "color.apca.title" = "Título";
 
 /* Body Text */
-"color.apca.body" = "Texto del cuerpo";
+"color.apca.body" = "Cuerpo";
 
 /* Pass */
 "color.wcag.pass" = "Conforme";

--- a/Pika/Assets/fr.lproj/Localizable.strings
+++ b/Pika/Assets/fr.lproj/Localizable.strings
@@ -164,7 +164,7 @@
 "color.ratio.description" = "Le rapport de contraste est une mesure de la différence de luminosité perçue entre deux couleurs, utilisée pour calculer le rapport de contraste.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Valeur de Contraste (Lc)";
+"color.lc" = "Contraste (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "Le contraste de luminosité (Lc) est une mesure de la différence de luminosité entre deux couleurs, utilisée pour calculer la valeur de contraste.";
@@ -212,7 +212,7 @@
 "color.apca.title" = "Titre";
 
 /* Body Text */
-"color.apca.body" = "Corps de texte";
+"color.apca.body" = "Corps";
 
 /* Pass */
 "color.wcag.pass" = "Conforme";

--- a/Pika/Assets/fr.lproj/Localizable.strings
+++ b/Pika/Assets/fr.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "Sélectionner premier plan et arrière-plan";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "Ombre de la fenêtre";
+"preferences.shadow.options.always" = "Afficher l'ombre";
+"preferences.shadow.options.hiddenWhilePicking" = "Masquer l'ombre lors de la sélection";
+"preferences.shadow.options.never" = "Masquer l'ombre";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "Agrandir pour ajuster";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "Réglages de la fenêtre";

--- a/Pika/Assets/hr.lproj/Localizable.strings
+++ b/Pika/Assets/hr.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "Obje";
 
 /* Contrast ratio */
-"color.ratio" = "Omjer kontrasta";
+"color.ratio" = "Kontrast";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "Omjer kontrasta je mjera razlike u percipiranoj svjetlini između dviju boja i koristi se za izračun omjera kontrasta.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Vrijednost kontrasta svjetline";
+"color.lc" = "Kontrast (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "Kontrast svjetline je mjera razlike u svjetlini između dviju boja i koristi se za izračun vrijednosti kontrasta.";
@@ -212,7 +212,7 @@
 "color.apca.title" = "Naslov";
 
 /* Body Text */
-"color.apca.body" = "Glavni tekst";
+"color.apca.body" = "Tekst";
 
 /* Pass */
 "color.wcag.pass" = "Uspjelo";

--- a/Pika/Assets/hr.lproj/Localizable.strings
+++ b/Pika/Assets/hr.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "Odaberi prednju i pozadinsku boju";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "Sjena prozora";
+"preferences.shadow.options.always" = "Prikaži sjenu";
+"preferences.shadow.options.hiddenWhilePicking" = "Sakrij sjenu tijekom biranja";
+"preferences.shadow.options.never" = "Sakrij sjenu";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "Proširi za prilagodbu";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "Postavke prozora";

--- a/Pika/Assets/ja.lproj/Localizable.strings
+++ b/Pika/Assets/ja.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "前景色と背景色をピック";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "ウインドウの影";
+"preferences.shadow.options.always" = "影を表示";
+"preferences.shadow.options.hiddenWhilePicking" = "ピック中は影を非表示";
+"preferences.shadow.options.never" = "影を非表示";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "広げて表示";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "ウインドウ設定";

--- a/Pika/Assets/ja.lproj/Localizable.strings
+++ b/Pika/Assets/ja.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "両方";
 
 /* Contrast ratio */
-"color.ratio" = "コントラスト比";
+"color.ratio" = "コントラスト";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "コントラスト比は2色間の知覚輝度の差を示す指標で、コントラスト比の計算に使用されます。";
 
 /* Contrast Value (Lc) */
-"color.lc" = "コントラスト値（Lc）";
+"color.lc" = "コントラスト（Lc）";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "輝度コントラスト（Lc）は2色間の明度差を示す指標で、コントラスト値の計算に使用されます。";

--- a/Pika/Assets/pl.lproj/Localizable.strings
+++ b/Pika/Assets/pl.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "Wybierz pierwszy plan i tło";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "Cień okna";
+"preferences.shadow.options.always" = "Pokaż cień";
+"preferences.shadow.options.hiddenWhilePicking" = "Ukryj cień podczas wybierania";
+"preferences.shadow.options.never" = "Ukryj cień";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "Rozwiń, aby dopasować";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "Ustawienia okna";

--- a/Pika/Assets/pl.lproj/Localizable.strings
+++ b/Pika/Assets/pl.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "Oba";
 
 /* Contrast ratio */
-"color.ratio" = "Współczynnik kontrastu";
+"color.ratio" = "Kontrast";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "Współczynnik kontrastu to miara różnicy w postrzeganej jasności dwóch kolorów, służąca do obliczenia współczynnika kontrastu.";
 
 /* Contrast Value (Lc) */
-"color.lc" = "Wartość kontrastu jasności (Lc)";
+"color.lc" = "Kontrast (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "Kontrast jasności (Lc) to miara różnicy jasności między dwoma kolorami, służąca do obliczenia wartości kontrastu.";
@@ -212,7 +212,7 @@
 "color.apca.title" = "Tytuł";
 
 /* Body Text */
-"color.apca.body" = "Tekst główny";
+"color.apca.body" = "Tekst";
 
 /* Pass */
 "color.wcag.pass" = "zaliczona";

--- a/Pika/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hans.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "选择前景色和背景色";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "窗口阴影";
+"preferences.shadow.options.always" = "显示阴影";
+"preferences.shadow.options.hiddenWhilePicking" = "选择颜色时隐藏阴影";
+"preferences.shadow.options.never" = "隐藏阴影";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "展开以适应";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "窗口设置";

--- a/Pika/Assets/zh-Hans.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hans.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "两者";
 
 /* Contrast ratio */
-"color.ratio" = "对比度比例";
+"color.ratio" = "对比度";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "对比度比例是衡量两种颜色之间感知亮度差异的指标，用于计算对比度比例。";
 
 /* Contrast Value (Lc) */
-"color.lc" = "对比值 (Lc)";
+"color.lc" = "对比度 (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "亮度对比度 (Lc) 是衡量两种颜色之间亮度差异的指标，用于计算对比值。";

--- a/Pika/Assets/zh-Hant.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hant.lproj/Localizable.strings
@@ -551,13 +551,13 @@
 "color.pick.contrast" = "選擇前景色和背景色";
 
 /* Window shadow */
-"preferences.shadow.description" = "Window shadow";
-"preferences.shadow.options.always" = "Show shadow";
-"preferences.shadow.options.hiddenWhilePicking" = "Hide shadow while picking";
-"preferences.shadow.options.never" = "Hide shadow";
+"preferences.shadow.description" = "視窗陰影";
+"preferences.shadow.options.always" = "顯示陰影";
+"preferences.shadow.options.hiddenWhilePicking" = "選擇顏色時隱藏陰影";
+"preferences.shadow.options.never" = "隱藏陰影";
 
 /* Expand to fit */
-"content.expandToFit" = "Expand to fit";
+"content.expandToFit" = "展開以適應";
 
 /* Window Settings */
-"preferences.window.title" = "Window Settings";
+"preferences.window.title" = "視窗設置";

--- a/Pika/Assets/zh-Hant.lproj/Localizable.strings
+++ b/Pika/Assets/zh-Hant.lproj/Localizable.strings
@@ -158,13 +158,13 @@
 "color.standard.both" = "兩者";
 
 /* Contrast ratio */
-"color.ratio" = "對比度比例";
+"color.ratio" = "對比度";
 
 /* Contrast ratio is a measure of the difference in perceived brightness between two colors, used to calculate the contrast ratio. */
 "color.ratio.description" = "對比度比例是衡量兩種顏色之間感知亮度差異的指標，用於計算對比度比例。";
 
 /* Contrast Value (Lc) */
-"color.lc" = "對比值 (Lc)";
+"color.lc" = "對比度 (Lc)";
 
 /* Lightness contrast (Lc) is a measure of the lightness difference between two colors, used to calculate the contrast value. */
 "color.lc.description" = "亮度對比度 (Lc) 是衡量兩種顏色之間亮度差異的指標，用於計算對比值。";


### PR DESCRIPTION
The new UI strings added in 1.9.0 (Window Settings section, shadow dropdown, and the "Expand to fit" control) shipped as English fallbacks in the non-English locales. This translates them across all eight locales, matching each locale's existing phrasing (e.g. reusing the established "… while picking" / "Settings" wording from keys like `preferences.pick.hide`).

Keys translated in `de`, `es`, `fr`, `hr`, `ja`, `pl`, `zh-Hans`, `zh-Hant`:
- `preferences.window.title` — "Window Settings"
- `preferences.shadow.description` — "Window shadow"
- `preferences.shadow.options.always` — "Show shadow"
- `preferences.shadow.options.hiddenWhilePicking` — "Hide shadow while picking"
- `preferences.shadow.options.never` — "Hide shadow"
- `content.expandToFit` — "Expand to fit"

All eight `.strings` files pass `plutil -lint`.

**Note:** these are best-effort translations — worth a native-speaker pass before the stable 1.9.0, particularly the "Expand to fit" control wording and the Traditional Chinese window term (used 視窗). Targets `1.9.0` so it rides along to `main` with #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)