### PR TITLE
Use shared review standard instead of code-review plugin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,55 +3,32 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
-# Newest push to a PR wins; cancel stale review runs instead of piling up.
-concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+# A called workflow can only narrow the caller's permissions, never widen them.
+# Without this block the run fails at startup before any job is created.
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
-    # macOS so Claude can build/test the app (AppKit/SwiftUI) during a review;
-    # matches tests.yml. GitHub-hosted runners are free on public repos.
-    runs-on: macos-15
-    # Fail loudly instead of hanging up to GitHub's 6h default if a run wedges.
-    # A touch higher than Linux to allow for Xcode build time during review.
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 1
-
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.3.app
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          # --comment makes findings post as inline PR comments (default is silent).
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+  review:
+    # Standard lives in superhighfives/control-room so every repo reviews the
+    # same way. Repo-specific rules go in CLAUDE.md.
+    uses: superhighfives/control-room/.github/workflows/review.yml@main
+    with:
+      # Pinned to match tests.yml — macos-latest doesn't ship Xcode 16.3, so
+      # xcode-select fails there. Bump both together.
+      runs_on: macos-15
+      runtime: none
+      setup_command: sudo xcode-select -s /Applications/Xcode_16.3.app
+      # Build for testing rather than a full test run: it catches the compile
+      # errors that matter for review without the runtime cost of the suite,
+      # which tests.yml already covers.
+      verify_commands: |
+        set -o pipefail && xcodebuild build-for-testing -project Pika.xcodeproj -scheme Pika -destination 'platform=macOS' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO 2>&1 | tail -40
+      timeout_minutes: 30
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Points this repo at the reusable workflow in [superhighfives/control-room](https://github.com/superhighfives/control-room), matching nylon-impossible, nowhere-forever and records.

### Why

On [#242](https://github.com/superhighfives/pika/pull/242) the review check went green having posted nothing. The log shows the plugin ran normally in agent mode for ~43s and exited clean — its step-1 eligibility check declined to review, most likely because the head branch is `claude/*` and it treats those as automated. Without `show_full_output` there's no way to confirm which criterion fired.

The plugin also discards any finding below 80 confidence and excludes pre-existing issues, likely-intentional changes, test coverage, and general code quality.

(The `--comment` flag in the old workflow was inert — the plugin command always posts a single summary and never parses it.)

### Swift support

`BASELINE.md` in control-room was written in TypeScript syntax, so on a Swift repo most rules didn't apply. It's now language-agnostic, with [`languages/swift.md`](https://github.com/superhighfives/control-room/blob/main/languages/swift.md) sharpening it into local forms: force-unwrap and `as!` as the "silence the compiler" escape hatch, `try!`, main-actor violations for UI state, and retain cycles in escaping closures.

### macOS runner

Runs on `macos-latest` with `runtime: none`, since the Swift toolchain is already there — `setup_command` only selects Xcode. `verify_commands` runs `build-for-testing`, mirroring [tests.yml](.github/workflows/tests.yml) but without the suite, which that workflow already covers. `timeout_minutes` raised to 30 for the build.

That means the reviewer compiles the project. On #242 that would have surfaced the exit-65 build failure as part of the review rather than only in a separate red check.

### Note

This PR edits `.github/workflows/`, so it can't review itself — the action requires the workflow file to match the default branch. Expect a comment from control-room explaining that rather than silence; it'll be the first live exercise of that fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)