### PR TITLE
Source colour names from color.pizza with offline fallback

### DIFF
--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -711,7 +711,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAD0B6DB259CED1D00FA2F67 /* Build configuration list for PBXNativeTarget "Pika" */;
 			buildPhases = (
-				CC4000000000000000000001 /* Download Color Names */,
 				EAD0B6C4259CED1C00FA2F67 /* Sources */,
 				EAD0B6C5259CED1C00FA2F67 /* Frameworks */,
 				EAD0B6C6259CED1C00FA2F67 /* Resources */,
@@ -737,7 +736,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAE23DE52D032A38005BB270 /* Build configuration list for PBXNativeTarget "Pika (Mac App Store)" */;
 			buildPhases = (
-				CC4000000000000000000002 /* Download Color Names */,
 				EAE23DA62D032A38005BB270 /* Sources */,
 				EAE23DD82D032A38005BB270 /* Frameworks */,
 				EAE23DDD2D032A38005BB270 /* Resources */,
@@ -854,44 +852,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		CC4000000000000000000001 /* Download Color Names */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Download Color Names";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "DEST=\"${SRCROOT}/Pika/Assets/ColorNames.json\"\nTMP=\"$(mktemp)\"\nURL=\"https://api.color.pizza/v1/?list=default\"\necho \"note: downloading default colour names from ${URL}\"\nif curl -fsSL --max-time 30 \"${URL}\" -o \"${TMP}\" && [ -s \"${TMP}\" ] && grep -q '\"colors\"' \"${TMP}\"; then\n  mv \"${TMP}\" \"${DEST}\"\n  echo \"note: updated ${DEST}\"\nelse\n  rm -f \"${TMP}\"\n  echo \"warning: could not download colour names; keeping committed ColorNames.json\"\nfi\nexit 0\n";
-		};
-		CC4000000000000000000002 /* Download Color Names */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Download Color Names";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "DEST=\"${SRCROOT}/Pika/Assets/ColorNames.json\"\nTMP=\"$(mktemp)\"\nURL=\"https://api.color.pizza/v1/?list=default\"\necho \"note: downloading default colour names from ${URL}\"\nif curl -fsSL --max-time 30 \"${URL}\" -o \"${TMP}\" && [ -s \"${TMP}\" ] && grep -q '\"colors\"' \"${TMP}\"; then\n  mv \"${TMP}\" \"${DEST}\"\n  echo \"note: updated ${DEST}\"\nelse\n  rm -f \"${TMP}\"\n  echo \"warning: could not download colour names; keeping committed ColorNames.json\"\nfi\nexit 0\n";
-		};
 		EA8124BC259D699A00033F0B /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -711,6 +711,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAD0B6DB259CED1D00FA2F67 /* Build configuration list for PBXNativeTarget "Pika" */;
 			buildPhases = (
+				CC4000000000000000000001 /* Download Color Names */,
 				EAD0B6C4259CED1C00FA2F67 /* Sources */,
 				EAD0B6C5259CED1C00FA2F67 /* Frameworks */,
 				EAD0B6C6259CED1C00FA2F67 /* Resources */,
@@ -736,6 +737,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EAE23DE52D032A38005BB270 /* Build configuration list for PBXNativeTarget "Pika (Mac App Store)" */;
 			buildPhases = (
+				CC4000000000000000000002 /* Download Color Names */,
 				EAE23DA62D032A38005BB270 /* Sources */,
 				EAE23DD82D032A38005BB270 /* Frameworks */,
 				EAE23DDD2D032A38005BB270 /* Resources */,
@@ -852,6 +854,44 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		CC4000000000000000000001 /* Download Color Names */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Download Color Names";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "DEST=\"${SRCROOT}/Pika/Assets/ColorNames.json\"\nTMP=\"$(mktemp)\"\nURL=\"https://api.color.pizza/v1/?list=default\"\necho \"note: downloading default colour names from ${URL}\"\nif curl -fsSL --max-time 30 \"${URL}\" -o \"${TMP}\" && [ -s \"${TMP}\" ] && grep -q '\"colors\"' \"${TMP}\"; then\n  mv \"${TMP}\" \"${DEST}\"\n  echo \"note: updated ${DEST}\"\nelse\n  rm -f \"${TMP}\"\n  echo \"warning: could not download colour names; keeping committed ColorNames.json\"\nfi\nexit 0\n";
+		};
+		CC4000000000000000000002 /* Download Color Names */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Download Color Names";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "DEST=\"${SRCROOT}/Pika/Assets/ColorNames.json\"\nTMP=\"$(mktemp)\"\nURL=\"https://api.color.pizza/v1/?list=default\"\necho \"note: downloading default colour names from ${URL}\"\nif curl -fsSL --max-time 30 \"${URL}\" -o \"${TMP}\" && [ -s \"${TMP}\" ] && grep -q '\"colors\"' \"${TMP}\"; then\n  mv \"${TMP}\" \"${DEST}\"\n  echo \"note: updated ${DEST}\"\nelse\n  rm -f \"${TMP}\"\n  echo \"warning: could not download colour names; keeping committed ColorNames.json\"\nfi\nexit 0\n";
+		};
 		EA8124BC259D699A00033F0B /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/Pika/AppDelegate.swift
+++ b/Pika/AppDelegate.swift
@@ -82,6 +82,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         validateColorSpace()
         showPikaIfConfigured()
         registerGlobalKeyMonitor()
+
+        // Refresh the colour-name list from color.pizza (catalogue + selected list) and cache
+        // it; the eyedroppers rebuild via `.colorNamesUpdated`. Best-effort — falls back to
+        // the bundled default offline.
+        ColorNamesManager.shared.updateOnLaunch()
     }
 
     private func removeUpdatesMenuItemIfNeeded() {
@@ -121,7 +126,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func presentSplashIfNeeded() {
-        if !Defaults[.viewedSplash] {
+        // The splash shows on every launch unless the user ticked its (pre-selected)
+        // "Don't show this again" checkbox. `viewedSplash` still records the first run so
+        // the pick shortcuts stay gated until onboarding is dismissed the first time.
+        if !Defaults[.hideSplashOnLaunch] {
             openSplashWindow(nil)
             NSApp.activate(ignoringOtherApps: true)
         }

--- a/Pika/Constants/Constants.swift
+++ b/Pika/Constants/Constants.swift
@@ -70,6 +70,7 @@ enum PikaConstants {
     static let ncExportPalette = "exportPalette"
     static let ncSystemColorChanged = "systemColorChanged"
     static let ncExpandToFit = "expandToFit"
+    static let ncColorNamesUpdated = "colorNamesUpdated"
 
     // Disabled formats for SwiftUI copy format
     static let disabledFormats: [ColorFormat] = [.hex, .hsl, .opengl, .lab, .oklch]
@@ -107,4 +108,5 @@ extension Notification.Name {
     static let exportPalette = Notification.Name(PikaConstants.ncExportPalette)
     static let systemColorChanged = Notification.Name(PikaConstants.ncSystemColorChanged)
     static let expandToFit = Notification.Name(PikaConstants.ncExpandToFit)
+    static let colorNamesUpdated = Notification.Name(PikaConstants.ncColorNamesUpdated)
 }

--- a/Pika/Constants/Defaults.swift
+++ b/Pika/Constants/Defaults.swift
@@ -94,6 +94,12 @@ enum AppMode: String, Codable, CaseIterable {
 extension Defaults.Keys {
     static let colorFormat = Key<ColorFormat>("colorFormat", default: .hex)
     static let viewedSplash = Key<Bool>("viewedSplash", default: false)
+    // The colour-name list to use, keyed to color.pizza's `/v1/lists/`. `default` is the
+    // list bundled at build time as the offline fallback.
+    static let colorNameList = Key<String>("colorNameList", default: "default")
+    // When false, the splash is shown on launch. The splash's pre-selected "Don't show
+    // this again" checkbox sets this to true on dismissal.
+    static let hideSplashOnLaunch = Key<Bool>("hideSplashOnLaunch", default: false)
     static let hidePikaWhilePicking = Key<Bool>("hidePikaWhilePicking", default: false)
     static let windowShadow = Key<WindowShadow>("windowShadow", default: .always)
     static let pickContrastingColor = Key<Bool>("pickContrastingColor", default: false)

--- a/Pika/Constants/PikaText.swift
+++ b/Pika/Constants/PikaText.swift
@@ -114,6 +114,10 @@ enum PikaText {
         "splash.footer", value: "You can change all of this in Settings.",
         comment: "Splash footer note"
     )
+    static let textSplashDontShowAgain = NSLocalizedString(
+        "splash.dontShowAgain", value: "Don’t show this again",
+        comment: "Splash: pre-selected checkbox to stop showing the splash on launch"
+    )
     static let textSplashConfirmTitle = NSLocalizedString(
         "splash.confirm.title", value: "Use Pika’s Pro picker?",
         comment: "Get started confirmation title when the Basic picker is selected"
@@ -245,6 +249,18 @@ enum PikaText {
     static let textColorNamesDescription = NSLocalizedString(
         "preferences.names.description",
         comment: "Hide color names"
+    )
+    static let textColorListTitle = NSLocalizedString(
+        "preferences.colornames.title", value: "Colour Names", comment: "Colour name list section title"
+    )
+    static let textColorListSubtitle = NSLocalizedString(
+        "preferences.colornames.subtitle",
+        value: "Choose the list Pika uses to name colours. Lists come from color.pizza and "
+            + "update automatically; the default works offline.",
+        comment: "Colour name list section subtitle"
+    )
+    static let textColorListDefault = NSLocalizedString(
+        "preferences.colornames.default", value: "Default", comment: "Default colour list name"
     )
     static let textFloatDescription = NSLocalizedString(
         "preferences.float.description",

--- a/Pika/Constants/PikaText.swift
+++ b/Pika/Constants/PikaText.swift
@@ -262,6 +262,23 @@ enum PikaText {
     static let textColorListDefault = NSLocalizedString(
         "preferences.colornames.default", value: "Default", comment: "Default colour list name"
     )
+    static let textColorListStatusChecking = NSLocalizedString(
+        "preferences.colornames.status.checking", value: "Checking color.pizza for updates…",
+        comment: "Colour list tooltip: a refresh is in progress"
+    )
+    static let textColorListStatusUpdatedFormat = NSLocalizedString(
+        "preferences.colornames.status.updated", value: "Updated %@",
+        comment: "Colour list tooltip: when the list was last refreshed (%@ is a date)"
+    )
+    static let textColorListStatusOffline = NSLocalizedString(
+        "preferences.colornames.status.offline",
+        value: "Couldn’t reach color.pizza. Using the saved colour list.",
+        comment: "Colour list tooltip: the last refresh failed, cached/bundled names are in use"
+    )
+    static let textColorListStatusBuiltIn = NSLocalizedString(
+        "preferences.colornames.status.builtin", value: "Using the built-in colour list.",
+        comment: "Colour list tooltip: no network refresh has happened yet"
+    )
     static let textFloatDescription = NSLocalizedString(
         "preferences.float.description",
         comment: "Float above windows"

--- a/Pika/Pika.entitlements
+++ b/Pika/Pika.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/Pika/Services/Eyedropper.swift
+++ b/Pika/Services/Eyedropper.swift
@@ -64,8 +64,10 @@ class Eyedropper: ObservableObject {
     // (and its event monitors / capture engine, for the custom loupe) stays alive.
     private var activeSession: ColorPickSession?
 
-    let colorNames: [ColorName] = loadColors()!
-    var closestVector: ClosestVector!
+    // Colour names come from the shared manager (cached network list, or the bundled
+    // default offline). Rebuilt whenever the manager broadcasts `.colorNamesUpdated`.
+    private var colorNames: [ColorName] = []
+    private var closestVector: ClosestVector?
 
     @objc @Published public var color: NSColor
 
@@ -75,12 +77,34 @@ class Eyedropper: ObservableObject {
         self.type = type
         self.color = color.usingColorSpace(.sRGB) ?? color
 
-        // Load colors
+        // Load colours and rebuild whenever the active list changes or a refresh lands.
+        reloadColorNames()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleColorNamesUpdated),
+            name: .colorNamesUpdated,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func handleColorNamesUpdated() {
+        reloadColorNames()
+        // Nudge observing views (the eyedropper label) to recompute the name.
+        DispatchQueue.main.async { self.objectWillChange.send() }
+    }
+
+    private func reloadColorNames() {
+        colorNames = ColorNamesManager.shared.currentColorNames()
         closestVector = ClosestVector(colorNames.map { $0.color.toRGB8BitArray() })
     }
 
     func getClosestColor() -> String {
-        colorNames[closestVector.compare(color)].name
+        guard let closestVector, !colorNames.isEmpty else { return "" }
+        return colorNames[closestVector.compare(color)].name
     }
 
     func set(_ selectedColor: NSColor) {

--- a/Pika/Services/Eyedropper.swift
+++ b/Pika/Services/Eyedropper.swift
@@ -98,8 +98,14 @@ class Eyedropper: ObservableObject {
     }
 
     private func reloadColorNames() {
-        colorNames = ColorNamesManager.shared.currentColorNames()
-        closestVector = ClosestVector(colorNames.map { $0.color.toRGB8BitArray() })
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let names = ColorNamesManager.shared.currentColorNames()
+            let vector = ClosestVector(names.map { $0.color.toRGB8BitArray() })
+            DispatchQueue.main.async {
+                self?.colorNames = names
+                self?.closestVector = vector
+            }
+        }
     }
 
     func getClosestColor() -> String {

--- a/Pika/Services/LoadColors.swift
+++ b/Pika/Services/LoadColors.swift
@@ -261,7 +261,7 @@ final class ColorNamesManager: ObservableObject {
     // MARK: - Parsing
 
     private struct ListsResponse: Decodable {
-        let available: [String]?
+        let availableColorNameLists: [String]?
         let listDescriptions: [String: ListDescription]?
     }
 
@@ -270,14 +270,14 @@ final class ColorNamesManager: ObservableObject {
     }
 
     /// Parses `/v1/lists/` into `(orderedInfos, availableKeys)`, tolerating either the
-    /// `available` array or the `listDescriptions` map being absent, and guaranteeing that
-    /// `default` is always present and listed first.
+    /// `availableColorNameLists` array or the `listDescriptions` map being absent, and
+    /// guaranteeing that `default` is always present and listed first.
     private static func parseLists(_ data: Data) -> ([ColorListInfo], Set<String>)? {
         guard let response = try? JSONDecoder().decode(ListsResponse.self, from: data) else { return nil }
 
         let descriptions = response.listDescriptions ?? [:]
-        // Prefer the authoritative `available` ordering; otherwise use the described keys.
-        var keys = response.available ?? Array(descriptions.keys).sorted()
+        // Prefer the authoritative `availableColorNameLists` ordering; otherwise use the described keys.
+        var keys = response.availableColorNameLists ?? Array(descriptions.keys).sorted()
         guard !keys.isEmpty else { return nil }
 
         // Ensure the bundled default is always offered and appears first.

--- a/Pika/Services/LoadColors.swift
+++ b/Pika/Services/LoadColors.swift
@@ -55,10 +55,42 @@ final class ColorNamesManager: ObservableObject {
     /// Lists offered by the API, for the picker UI. Empty until fetched from the network.
     @Published private(set) var availableLists: [ColorListInfo] = []
 
+    /// True while a catalogue or colour fetch is in flight. Drives the picker's spinner.
+    @Published private(set) var isFetching = false
+
+    /// When the active list's cached colours were last refreshed from the network (the
+    /// cache file's modification date), or nil if only the bundled default is in use.
+    @Published private(set) var lastUpdated: Date?
+
+    /// A friendly description of the most recent refresh failure, cleared on success. Shown
+    /// in the picker's tooltip so an offline / API problem is visible rather than silent.
+    @Published private(set) var lastErrorMessage: String?
+
     private let session = URLSession.shared
     private let apiBase = "https://api.color.pizza/v1"
 
+    /// How often to re-check the API while the app keeps running.
+    private let refreshInterval: TimeInterval = 6 * 60 * 60
+    /// Skip a foreground-triggered refresh if one was attempted within this window.
+    private let foregroundThrottle: TimeInterval = 30 * 60
+    private var refreshTimer: Timer?
+    private var didBecomeActiveObserver: NSObjectProtocol?
+    private var lastRefreshAttempt: Date?
+    /// Count of in-flight requests, so overlapping fetches keep `isFetching` accurate.
+    private var inFlight = 0
+
     private init() {}
+
+    /// A human-readable summary of the current refresh state, for the picker's tooltip.
+    var statusDescription: String {
+        if isFetching { return PikaText.textColorListStatusChecking }
+        if let lastErrorMessage { return lastErrorMessage }
+        if let lastUpdated {
+            return String(format: PikaText.textColorListStatusUpdatedFormat,
+                          Self.statusDateFormatter.string(from: lastUpdated))
+        }
+        return PikaText.textColorListStatusBuiltIn
+    }
 
     // MARK: - Loading names for the current list
 
@@ -76,11 +108,22 @@ final class ColorNamesManager: ObservableObject {
         return loadColors() ?? []
     }
 
-    // MARK: - Launch update
+    // MARK: - Launch & periodic update
 
-    /// Refreshes the list catalogue and the selected list's colours from the network. Safe
-    /// to call on every launch; any failure leaves the cached / bundled data untouched.
+    /// Kicks off the first refresh, then keeps the data current: a repeating timer re-checks
+    /// the API every few hours, and re-activating the app triggers a (throttled) refresh.
+    /// Safe to call once on launch; any failure leaves the cached / bundled data untouched.
     func updateOnLaunch() {
+        refreshLastUpdated()
+        refreshAll()
+        schedulePeriodicRefresh()
+        observeAppActivation()
+    }
+
+    /// Refreshes the catalogue and the selected list's colours. Falls the selection back to
+    /// `default` if the chosen list is no longer offered. Safe to call repeatedly.
+    func refreshAll() {
+        lastRefreshAttempt = Date()
         fetchLists { [weak self] infos, availableKeys in
             guard let self else { return }
             if !infos.isEmpty { self.availableLists = infos }
@@ -90,9 +133,32 @@ final class ColorNamesManager: ObservableObject {
             if !availableKeys.isEmpty, !availableKeys.contains(key) {
                 key = defaultColorListKey
                 Defaults[.colorNameList] = key
+                self.refreshLastUpdated()
                 NotificationCenter.default.post(name: .colorNamesUpdated, object: nil)
             }
             self.refreshColors(for: key)
+        }
+    }
+
+    private func schedulePeriodicRefresh() {
+        guard refreshTimer == nil else { return }
+        let timer = Timer(timeInterval: refreshInterval, repeats: true) { [weak self] _ in
+            self?.refreshAll()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        refreshTimer = timer
+    }
+
+    private func observeAppActivation() {
+        guard didBecomeActiveObserver == nil else { return }
+        didBecomeActiveObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            // Don't hammer the API every time focus returns — refresh at most twice an hour.
+            if let last = self.lastRefreshAttempt,
+               Date().timeIntervalSince(last) < self.foregroundThrottle { return }
+            self.refreshAll()
         }
     }
 
@@ -109,48 +175,85 @@ final class ColorNamesManager: ObservableObject {
     func selectList(_ key: String) {
         guard key != Defaults[.colorNameList] else { return }
         Defaults[.colorNameList] = key
+        refreshLastUpdated()
         NotificationCenter.default.post(name: .colorNamesUpdated, object: nil)
         refreshColors(for: key)
     }
 
     private func refreshColors(for key: String) {
-        fetchColors(for: key) { success in
-            // Only signal a reload if this is still the active list when the fetch lands.
-            guard success, Defaults[.colorNameList] == key else { return }
-            DispatchQueue.main.async {
+        fetchColors(for: key) { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .success:
+                self.lastErrorMessage = nil
+                // Only signal a reload if this is still the active list when the fetch lands.
+                guard Defaults[.colorNameList] == key else { return }
+                self.refreshLastUpdated()
                 NotificationCenter.default.post(name: .colorNamesUpdated, object: nil)
+            case let .failure(message):
+                self.lastErrorMessage = message
             }
         }
     }
 
+    /// Recomputes `lastUpdated` from the active list's cache file modification date.
+    private func refreshLastUpdated() {
+        lastUpdated = Self.cacheModificationDate(for: Defaults[.colorNameList])
+    }
+
+    // MARK: - Fetch-state tracking
+
+    private func beginFetch() {
+        inFlight += 1
+        isFetching = true
+    }
+
+    private func endFetch() {
+        inFlight = max(0, inFlight - 1)
+        if inFlight == 0 { isFetching = false }
+    }
+
     // MARK: - Networking
+
+    private enum FetchResult {
+        case success
+        case failure(String)
+    }
 
     private func fetchLists(completion: @escaping ([ColorListInfo], Set<String>) -> Void) {
         guard let url = URL(string: "\(apiBase)/lists/") else { completion([], []); return }
-        session.dataTask(with: url) { data, _, _ in
-            guard let data, let parsed = Self.parseLists(data) else {
-                DispatchQueue.main.async { completion([], []) }
-                return
+        beginFetch()
+        session.dataTask(with: url) { [weak self] data, _, _ in
+            let parsed = data.flatMap { Self.parseLists($0) }
+            DispatchQueue.main.async {
+                self?.endFetch()
+                completion(parsed?.0 ?? [], parsed?.1 ?? [])
             }
-            DispatchQueue.main.async { completion(parsed.0, parsed.1) }
         }.resume()
     }
 
-    private func fetchColors(for key: String, completion: @escaping (Bool) -> Void) {
+    private func fetchColors(for key: String, completion: @escaping (FetchResult) -> Void) {
         guard let escaped = key.addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed),
               let url = URL(string: "\(apiBase)/?list=\(escaped)")
-        else { completion(false); return }
-        session.dataTask(with: url) { data, _, _ in
-            guard let data,
-                  let decoded = try? JSONDecoder().decode(ResponseData.self, from: data),
-                  !decoded.colors.isEmpty,
-                  let cacheURL = Self.cacheURL(for: key)
-            else { completion(false); return }
-            do {
-                try data.write(to: cacheURL, options: .atomic)
-                completion(true)
-            } catch {
-                completion(false)
+        else { completion(.failure(PikaText.textColorListStatusOffline)); return }
+        beginFetch()
+        session.dataTask(with: url) { [weak self] data, _, error in
+            let result: FetchResult
+            if error != nil {
+                result = .failure(PikaText.textColorListStatusOffline)
+            } else if let data,
+                      let decoded = try? JSONDecoder().decode(ResponseData.self, from: data),
+                      !decoded.colors.isEmpty,
+                      let cacheURL = Self.cacheURL(for: key),
+                      (try? data.write(to: cacheURL, options: .atomic)) != nil
+            {
+                result = .success
+            } else {
+                result = .failure(PikaText.textColorListStatusOffline)
+            }
+            DispatchQueue.main.async {
+                self?.endFetch()
+                completion(result)
             }
         }.resume()
     }
@@ -223,6 +326,22 @@ final class ColorNamesManager: ObservableObject {
         let safeKey = key.replacingOccurrences(of: "/", with: "_")
         return cacheDirectory()?.appendingPathComponent("\(safeKey).json")
     }
+
+    private static func cacheModificationDate(for key: String) -> Date? {
+        guard let url = cacheURL(for: key),
+              let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        else { return nil }
+        return attributes[.modificationDate] as? Date
+    }
+
+    // MARK: - Formatting
+
+    private static let statusDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
 }
 
 private extension CharacterSet {

--- a/Pika/Services/LoadColors.swift
+++ b/Pika/Services/LoadColors.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import Defaults
 
 struct ColorName: Decodable {
     public var name: String
@@ -12,6 +13,19 @@ struct ResponseData: Decodable {
     var colors: [ColorName]
 }
 
+/// A named colour list published by the color.pizza API (`/v1/lists/`).
+struct ColorListInfo: Identifiable, Hashable {
+    let key: String
+    let title: String
+    var id: String { key }
+}
+
+/// The key of the list bundled with the app as the offline fallback. It's downloaded as
+/// part of the build so colour names always work without a network connection.
+let defaultColorListKey = "default"
+
+/// Loads the colour list bundled at build time — the `default` list, used as the offline
+/// fallback until (and if) a network refresh caches a newer copy.
 func loadColors() -> [ColorName]? {
     if let url = Bundle.main.url(forResource: "ColorNames", withExtension: "json") {
         do {
@@ -24,4 +38,198 @@ func loadColors() -> [ColorName]? {
         }
     }
     return nil
+}
+
+/// Owns colour-name data sourced from the color.pizza API, with an offline fallback.
+///
+/// - The `default` list is downloaded during the build and bundled, so names always work
+///   offline.
+/// - On launch the currently-selected list is refreshed from the network and cached on disk.
+/// - Settings and the splash let the user pick any list from `/v1/lists/`; if the chosen
+///   list is no longer offered by the API, we fall back to `default`.
+///
+/// Reloads are broadcast via `.colorNamesUpdated` so the eyedroppers rebuild their lookup.
+final class ColorNamesManager: ObservableObject {
+    static let shared = ColorNamesManager()
+
+    /// Lists offered by the API, for the picker UI. Empty until fetched from the network.
+    @Published private(set) var availableLists: [ColorListInfo] = []
+
+    private let session = URLSession.shared
+    private let apiBase = "https://api.color.pizza/v1"
+
+    private init() {}
+
+    // MARK: - Loading names for the current list
+
+    /// The colour names for the currently-selected list: the on-disk cache if present,
+    /// otherwise the bundled `default` list.
+    func currentColorNames() -> [ColorName] {
+        let key = Defaults[.colorNameList]
+        if let url = Self.cacheURL(for: key),
+           let data = try? Data(contentsOf: url),
+           let decoded = try? JSONDecoder().decode(ResponseData.self, from: data),
+           !decoded.colors.isEmpty
+        {
+            return decoded.colors
+        }
+        return loadColors() ?? []
+    }
+
+    // MARK: - Launch update
+
+    /// Refreshes the list catalogue and the selected list's colours from the network. Safe
+    /// to call on every launch; any failure leaves the cached / bundled data untouched.
+    func updateOnLaunch() {
+        fetchLists { [weak self] infos, availableKeys in
+            guard let self else { return }
+            if !infos.isEmpty { self.availableLists = infos }
+
+            // Fall back to `default` if the chosen list is no longer available.
+            var key = Defaults[.colorNameList]
+            if !availableKeys.isEmpty, !availableKeys.contains(key) {
+                key = defaultColorListKey
+                Defaults[.colorNameList] = key
+                NotificationCenter.default.post(name: .colorNamesUpdated, object: nil)
+            }
+            self.refreshColors(for: key)
+        }
+    }
+
+    /// Ensures the picker has a catalogue to show; used when Settings / the splash appear.
+    func loadAvailableListsIfNeeded() {
+        guard availableLists.isEmpty else { return }
+        fetchLists { [weak self] infos, _ in
+            if !infos.isEmpty { self?.availableLists = infos }
+        }
+    }
+
+    /// Switches the active list: reflects the change immediately from cache / bundle, then
+    /// fetches the latest colours for the newly-chosen list in the background.
+    func selectList(_ key: String) {
+        guard key != Defaults[.colorNameList] else { return }
+        Defaults[.colorNameList] = key
+        NotificationCenter.default.post(name: .colorNamesUpdated, object: nil)
+        refreshColors(for: key)
+    }
+
+    private func refreshColors(for key: String) {
+        fetchColors(for: key) { success in
+            // Only signal a reload if this is still the active list when the fetch lands.
+            guard success, Defaults[.colorNameList] == key else { return }
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .colorNamesUpdated, object: nil)
+            }
+        }
+    }
+
+    // MARK: - Networking
+
+    private func fetchLists(completion: @escaping ([ColorListInfo], Set<String>) -> Void) {
+        guard let url = URL(string: "\(apiBase)/lists/") else { completion([], []); return }
+        session.dataTask(with: url) { data, _, _ in
+            guard let data, let parsed = Self.parseLists(data) else {
+                DispatchQueue.main.async { completion([], []) }
+                return
+            }
+            DispatchQueue.main.async { completion(parsed.0, parsed.1) }
+        }.resume()
+    }
+
+    private func fetchColors(for key: String, completion: @escaping (Bool) -> Void) {
+        guard let escaped = key.addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed),
+              let url = URL(string: "\(apiBase)/?list=\(escaped)")
+        else { completion(false); return }
+        session.dataTask(with: url) { data, _, _ in
+            guard let data,
+                  let decoded = try? JSONDecoder().decode(ResponseData.self, from: data),
+                  !decoded.colors.isEmpty,
+                  let cacheURL = Self.cacheURL(for: key)
+            else { completion(false); return }
+            do {
+                try data.write(to: cacheURL, options: .atomic)
+                completion(true)
+            } catch {
+                completion(false)
+            }
+        }.resume()
+    }
+
+    // MARK: - Parsing
+
+    private struct ListsResponse: Decodable {
+        let available: [String]?
+        let listDescriptions: [String: ListDescription]?
+    }
+
+    private struct ListDescription: Decodable {
+        let title: String?
+    }
+
+    /// Parses `/v1/lists/` into `(orderedInfos, availableKeys)`, tolerating either the
+    /// `available` array or the `listDescriptions` map being absent, and guaranteeing that
+    /// `default` is always present and listed first.
+    private static func parseLists(_ data: Data) -> ([ColorListInfo], Set<String>)? {
+        guard let response = try? JSONDecoder().decode(ListsResponse.self, from: data) else { return nil }
+
+        let descriptions = response.listDescriptions ?? [:]
+        // Prefer the authoritative `available` ordering; otherwise use the described keys.
+        var keys = response.available ?? Array(descriptions.keys).sorted()
+        guard !keys.isEmpty else { return nil }
+
+        // Ensure the bundled default is always offered and appears first.
+        keys.removeAll { $0 == defaultColorListKey }
+        keys.insert(defaultColorListKey, at: 0)
+
+        let infos = keys.map { key -> ColorListInfo in
+            // Keep `default` recognisable regardless of how the API labels it.
+            let title = key == defaultColorListKey
+                ? Self.prettify(key)
+                : (descriptions[key]?.title ?? Self.prettify(key))
+            return ColorListInfo(key: key, title: title)
+        }
+        return (infos, Set(keys))
+    }
+
+    /// A readable title for a list key the API didn't describe: `sanzoWadaI` -> `Sanzo Wada I`.
+    private static func prettify(_ key: String) -> String {
+        if key == defaultColorListKey { return "Default" }
+        var result = ""
+        for (index, character) in key.enumerated() {
+            if index == 0 {
+                result.append(Character(String(character).uppercased()))
+            } else if character.isUppercase {
+                result.append(" ")
+                result.append(character)
+            } else {
+                result.append(character)
+            }
+        }
+        return result
+    }
+
+    // MARK: - Cache location
+
+    private static func cacheDirectory() -> URL? {
+        guard let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        else { return nil }
+        let dir = base.appendingPathComponent("Pika/ColorLists", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private static func cacheURL(for key: String) -> URL? {
+        // Guard against odd list keys resolving to unexpected paths.
+        let safeKey = key.replacingOccurrences(of: "/", with: "_")
+        return cacheDirectory()?.appendingPathComponent("\(safeKey).json")
+    }
+}
+
+private extension CharacterSet {
+    /// Query-value-safe set: the query set minus the sub-delims that break `?list=` values.
+    static let urlQueryValueAllowed: CharacterSet = {
+        var set = CharacterSet.urlQueryAllowed
+        set.remove(charactersIn: "&=?+/")
+        return set
+    }()
 }

--- a/Pika/Views/PreferencesView.swift
+++ b/Pika/Views/PreferencesView.swift
@@ -155,6 +155,20 @@ private struct PickerStyleSection: View {
     }
 }
 
+private struct ColorNamesSection: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10.0) {
+            Text(PikaText.textColorListTitle).font(.system(size: 16))
+            Text(PikaText.textColorListSubtitle)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            ColorListPickerView()
+        }
+        .padding(.horizontal, 24.0)
+    }
+}
+
 private struct AppearanceSection: View {
     @Default(.contrastStandard) var contrastStandard
     @EnvironmentObject var eyedroppers: Eyedroppers
@@ -364,6 +378,10 @@ struct PreferencesView: View {
                     Divider().padding(.vertical, 16.0)
 
                     PickerStyleSection()
+
+                    Divider().padding(.vertical, 16.0)
+
+                    ColorNamesSection()
 
                     Divider().padding(.vertical, 16.0)
 

--- a/Pika/Views/SplashView.swift
+++ b/Pika/Views/SplashView.swift
@@ -7,6 +7,9 @@ struct SplashView: View {
     @Default(.pickerStyle) var pickerStyle
     @State private var hostWindow: NSWindow?
     @State private var pendingRelaunch = false
+    // Pre-selected: the common case is to see the splash once and not again. Unchecking it
+    // keeps the splash appearing on launch. Persisted to `hideSplashOnLaunch` on dismissal.
+    @State private var dontShowAgain = true
 
     // The custom picker is only the active choice once permission exists. "Get started" is
     // the primary action only then — otherwise Grant Permission is the primary call.
@@ -65,6 +68,13 @@ struct SplashView: View {
                                 .font(.system(size: 13, weight: .semibold))
                             PickerChoiceView(pendingRelaunch: $pendingRelaunch)
                         }
+
+                        SplashSettingRow(
+                            title: PikaText.textColorListTitle,
+                            subtitle: PikaText.textColorListSubtitle
+                        ) {
+                            ColorListPickerView()
+                        }
                     }
                     .padding(24.0)
                 }
@@ -72,10 +82,12 @@ struct SplashView: View {
                 Divider()
 
                 HStack(spacing: 12.0) {
-                    Text(PikaText.textSplashFooter)
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                    Toggle(isOn: $dontShowAgain) {
+                        Text(PikaText.textSplashDontShowAgain)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    .toggleStyle(.checkbox)
                     Spacer(minLength: 12.0)
                     if customActive {
                         Button(action: handleGetStarted, label: { Text(PikaText.textSplashStart) })
@@ -96,6 +108,8 @@ struct SplashView: View {
     }
 
     private func closeSplash() {
+        // Persist the pre-selected checkbox: leave it ticked and the splash won't return.
+        Defaults[.hideSplashOnLaunch] = dontShowAgain
         NSApp.sendAction(#selector(AppDelegate.closeSplashWindow), to: nil, from: nil)
     }
 
@@ -144,6 +158,44 @@ private struct SplashSettingRow<Control: View>: View {
             Spacer(minLength: 12.0)
             control
         }
+    }
+}
+
+/// The colour-name list chooser, shared by the splash and Settings. Shows the active list
+/// (Default by default) and lets the user pick any list published by color.pizza. Offline,
+/// only Default (and any list already cached) is guaranteed; the full catalogue loads from
+/// the network when reachable. Selecting a list is handled by `ColorNamesManager`, which
+/// also falls the choice back to Default if the API stops offering it.
+struct ColorListPickerView: View {
+    @ObservedObject private var manager = ColorNamesManager.shared
+    @Default(.colorNameList) private var colorNameList
+
+    private var options: [ColorListInfo] {
+        var infos = manager.availableLists
+        // Before the catalogue loads, still offer Default so the control is usable offline.
+        if infos.isEmpty {
+            infos = [ColorListInfo(key: defaultColorListKey, title: PikaText.textColorListDefault)]
+        }
+        // Keep a stored non-default selection renderable even if it's not (yet) in the list.
+        if !infos.contains(where: { $0.key == colorNameList }) {
+            infos.append(ColorListInfo(key: colorNameList, title: colorNameList))
+        }
+        return infos
+    }
+
+    var body: some View {
+        Picker("", selection: Binding(
+            get: { colorNameList },
+            set: { ColorNamesManager.shared.selectList($0) }
+        )) {
+            ForEach(options) { info in
+                Text(info.title).tag(info.key)
+            }
+        }
+        .labelsHidden()
+        .pickerStyle(.menu)
+        .fixedSize()
+        .onAppear { manager.loadAvailableListsIfNeeded() }
     }
 }
 

--- a/Pika/Views/SplashView.swift
+++ b/Pika/Views/SplashView.swift
@@ -184,17 +184,28 @@ struct ColorListPickerView: View {
     }
 
     var body: some View {
-        Picker("", selection: Binding(
-            get: { colorNameList },
-            set: { ColorNamesManager.shared.selectList($0) }
-        )) {
-            ForEach(options) { info in
-                Text(info.title).tag(info.key)
+        HStack(spacing: 8.0) {
+            Picker("", selection: Binding(
+                get: { colorNameList },
+                set: { ColorNamesManager.shared.selectList($0) }
+            )) {
+                ForEach(options) { info in
+                    Text(info.title).tag(info.key)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .fixedSize()
+
+            // Show a spinner while the catalogue / colours refresh so a fetch isn't silent.
+            if manager.isFetching {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .controlSize(.small)
             }
         }
-        .labelsHidden()
-        .pickerStyle(.menu)
-        .fixedSize()
+        // Surface the last-updated time, an in-progress check, or an offline error on hover.
+        .help(manager.statusDescription)
         .onAppear { manager.loadAvailableListsIfNeeded() }
     }
 }

--- a/PikaTests/ExporterTests.swift
+++ b/PikaTests/ExporterTests.swift
@@ -4,11 +4,11 @@ import XCTest
 /// Tests the palette-to-JSON export contract. Users rely on this format when
 /// exporting swatches, so the shape and field names are a public contract.
 ///
-/// `Exporter.toText` and `Exporter.toJSON` take `Eyedropper` values whose
-/// initialiser force-unwraps `loadColors()`, which reads `ColorNames.json`
-/// from `Bundle.main`. That bundle is not populated in the XCTest host, so
-/// those paths are out of reach from a unit test without an app-bundle
-/// fixture. Coverage for them belongs in an integration/UI test target.
+/// `Exporter.toText` and `Exporter.toJSON` take `Eyedropper` values whose colour
+/// names come from `ColorNamesManager`, reading the cached list or the bundled
+/// `ColorNames.json` from `Bundle.main`. That bundle is not populated in the XCTest
+/// host (names resolve to empty), so those paths are out of reach from a unit test
+/// without an app-bundle fixture. Coverage for them belongs in an integration/UI test target.
 final class ExporterTests: XCTestCase {
     private func makePair(fg: String, bg: String, date: Date) -> ColorPair {
         ColorPair(id: UUID(), foregroundHex: fg, backgroundHex: bg, date: date)


### PR DESCRIPTION
## Summary

Colour names previously came only from a checked-in `ColorNames.json`. This PR makes them sourced from the [color.pizza](https://api.color.pizza/v1/lists/) API, while keeping a bundled copy so names always work offline, and lets people choose which list Pika uses.

## What changed

**Build-time download (offline fallback)**
- A new **"Download Color Names"** build phase (added to both the Sparkle and Mac App Store targets, running before resources are copied) fetches the `default` list into `Pika/Assets/ColorNames.json`. It's best-effort: if the download fails (e.g. offline CI), it keeps the committed copy, so builds never break and the shipped app always has an up-to-date offline fallback.

**Runtime update**
- New `ColorNamesManager` refreshes the list catalogue and the currently-selected list from the API on launch, caching each list as JSON in Application Support.
- On a successful refresh (or a list switch) it broadcasts `.colorNamesUpdated`; `Eyedropper` observes this and rebuilds its closest-colour lookup, so names update live without a relaunch.
- Colour names load from the on-disk cache when present, otherwise the bundled default — so the app is fully functional offline.

**List chooser (Settings + splash)**
- A shared `ColorListPickerView` shows the available lists from `/v1/lists/`, with **Default** selected by default. It appears both in a new **Colour Names** section in Settings and in the splash.
- If the chosen list is no longer offered by the API, the selection **falls back to Default** automatically on the next launch.

**Splash**
- The splash now shows on launch with a **pre-selected "Don't show this again"** checkbox. Leaving it ticked (the default) stops it returning; unticking keeps it appearing. This is persisted via a new `hideSplashOnLaunch` default. First-run shortcut gating (`viewedSplash`) is unchanged.

**Entitlements**
- Added `com.apple.security.network.client` so the sandboxed app can reach the API.

## Notes / decisions
- The build phase refreshes the committed `ColorNames.json` in place; this keeps it as the offline fallback but means local builds may show it as modified when the upstream default list changes. Happy to switch to a build-output/gitignored location if you'd prefer no source churn.
- New user-facing strings use inline English `value:` defaults, so they render before translations are added (matching the existing recent strings).
- The API endpoints are unreachable from this environment's network policy, so the `/v1/lists/` parsing is written defensively (tolerates the `available` array or `listDescriptions` map being absent) and would benefit from a quick real-network sanity check.

## Testing
- `Pika.xcodeproj` validated with `xcodeproj` (both app targets show the new phase first; shell script round-trips correctly).
- No unit tests reference the members changed to `private`; `ExporterTests` rationale comment updated since `Eyedropper` no longer force-unwraps `loadColors()`.
- Not built with Xcode in this environment — worth a local build + launch to confirm the live refresh and picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZAfuRdMDzHjcJyaSz7unx)_