### PR TITLE
Fix window outline/shadow stretching when dragged to screen top

### DIFF
--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -219,7 +219,7 @@ class WindowCoordinator: NSObject {
     }
 
     private func makeShadowWindow() -> NSWindow {
-        let window = NSWindow(
+        let window = CompanionWindow(
             contentRect: shadowFrame(),
             styleMask: .borderless,
             backing: .buffered,
@@ -240,7 +240,7 @@ class WindowCoordinator: NSObject {
     }
 
     private func makeBorderWindow() -> NSWindow {
-        let window = NSWindow(
+        let window = CompanionWindow(
             contentRect: borderFrame(),
             styleMask: .borderless,
             backing: .buffered,
@@ -440,6 +440,20 @@ class WindowCoordinator: NSObject {
         splashTouchBarController = SplashTouchBarController(window: splashWindow)
         splashWindow.contentView = NSHostingView(rootView: SplashView().ignoresSafeArea())
         splashWindow.fadeIn(nil)
+    }
+}
+
+/// A borderless, decorative companion window (the hairline border and the custom shadow)
+/// that must be free to extend past the top of the screen. AppKit's default
+/// `constrainFrameRect(_:to:)` clamps a window so its top edge stays below the menu bar;
+/// because these companions sit `borderPad`/`shadowPad` *beyond* the main window's frame,
+/// that clamp pins their top near the screen edge as the main window is dragged upward,
+/// while their height stays fixed — dragging their bottom edge down and detaching the
+/// outline/shadow from the window. They ignore mouse events and only trace the main frame,
+/// so opt out of constraining entirely and let them track it exactly, even off-screen.
+private final class CompanionWindow: NSWindow {
+    override func constrainFrameRect(_ frameRect: NSRect, to _: NSScreen?) -> NSRect {
+        frameRect
     }
 }
 


### PR DESCRIPTION
## The bug

Dragging the Pika window up toward the top of the screen makes the outline/shadow **grow and get stuck on the bottom axis** — the border and drop-shadow detach from the window and hang below it. It's obvious with the shadow set to **"Hidden while picking"** and imperceptible on **"Never"**.

## Root cause

The hairline border and the custom drop-shadow are drawn by separate borderless **companion windows** that track the main window's frame, sitting `borderPad` (6px) / `shadowPad` (60px) *beyond* it. On every move they're re-framed to `mainWindow.frame.insetBy(-pad)`.

An instrumented trace confirmed the mechanism — the main window never resizes (constant `506×318`), but the shadow window's origin gets clamped as it's dragged up:

```
parent.y=534 → shadow should be y=474, actual=474  ✓
parent.y=601 → shadow should be y=541, actual=485  ✗ stuck
```

AppKit's default `constrainFrameRect(_:to:)` won't let a window's top edge go under the menu bar. Because the companion sits above the main frame, its top hits that limit first and gets clamped — but its height stays fixed, so its bottom edge can't follow the window up and hangs ~56px below. The 6px border has the same flaw but it's too small to notice, which is exactly why only "Hidden while picking" (60px shadow) shows it.

## The fix

A small `CompanionWindow: NSWindow` subclass overrides `constrainFrameRect` to return the frame unchanged, used for both the border and shadow windows. They're decorative and `ignoresMouseEvents`, so letting them extend past the screen top is exactly what we want — they now track the main frame precisely.

## Testing

Built and ran the Debug build on macOS 26.5; dragging to the top of the screen now keeps the outline/shadow locked to the window in all shadow modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)