### PR TITLE
Pre-resolve SPM in review workflow to stop 30-min timeouts

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,8 +27,16 @@ jobs:
       # Build for testing rather than a full test run: it catches the compile
       # errors that matter for review without the runtime cost of the suite,
       # which tests.yml already covers.
+      #
+      # Resolve Swift packages first, as a separate step — same as tests.yml.
+      # Without it, build-for-testing resolves SPM cold, and the `| tail -40`
+      # buffers all output so nothing streams; the review agent sits on a build
+      # that can run past the timeout and gets cancelled without ever reviewing.
       verify_commands: |
+        xcodebuild -resolvePackageDependencies -project Pika.xcodeproj -scheme Pika
         set -o pipefail && xcodebuild build-for-testing -project Pika.xcodeproj -scheme Pika -destination 'platform=macOS' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO 2>&1 | tail -40
-      timeout_minutes: 30
+      # Safety net over the pre-resolve fix above, so a slow cold build can't get
+      # cancelled mid-review before Claude posts anything.
+      timeout_minutes: 45
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## What

The **Claude Code Review** workflow keeps getting **cancelled at its 30-minute cap** without ever posting a review (seen on #251 — `review / review` cancelled at `30m17s`).

## Why

The job hands the review agent a `xcodebuild build-for-testing` to run and report on. Two things compound:

- Swift packages resolve **cold** inside `build-for-testing` (unlike `tests.yml`, which runs `-resolvePackageDependencies` as a separate step first and builds in ~90s).
- `2>&1 | tail -40` **buffers all output** — nothing streams, so the agent gets no incremental signal and sits on the build.

The build overruns `timeout_minutes: 30` and the runner cancels the job with `xcodebuild` still alive (`Terminate orphan process: … (xcodebuild)` in the run log). No review is posted, and the check shows cancelled/"not reviewed" — misleading, since the code is fine and Unit Tests pass.

## Fix

- Resolve Swift packages in a **separate step first**, mirroring `tests.yml`.
- Raise `timeout_minutes` to **45** as a safety net so a slow cold build can't get cancelled mid-review.

`| tail -40` is kept intentionally — the review agent wants a bounded tail (pass/fail + errors), not a flood of raw build output.

Note: this must merge to `main` (or the relevant base) rather than being fixed on an affected feature branch — the review action skips whenever a PR's copy of the workflow differs from base, so editing it on a feature branch would just skip the review there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)