### PR TITLE
fix: round query color to match named-color database 8-bit buckets

### DIFF
--- a/Pika/Services/ClosestVector.swift
+++ b/Pika/Services/ClosestVector.swift
@@ -16,7 +16,10 @@ public class ClosestVector {
 
     public func compare(_ val: NSColor) -> (Int) {
         guard let color = val.usingColorSpace(.sRGB) else { return 0 }
-        let colorArr = [Int(color.redComponent * 255), Int(color.greenComponent * 255), Int(color.blueComponent * 255)]
+        // Quantise with the same rounded helper used to build the named-color
+        // database (see Eyedropper + toRGB8BitArray), so the query and the
+        // database agree on every 8-bit bucket instead of truncate-vs-round.
+        let colorArr = color.toRGB8BitArray()
 
         var minDistance = Int.max
         var index = 0

--- a/PikaTests/ClosestVectorTests.swift
+++ b/PikaTests/ClosestVectorTests.swift
@@ -69,4 +69,27 @@ final class ClosestVectorTests: XCTestCase {
         let p3Red = NSColor(colorSpace: .displayP3, components: [1.0, 0.0, 0.0, 1.0], count: 4)
         XCTAssertEqual(cv.compare(p3Red), 1)
     }
+
+    // MARK: - compare() quantisation (truncate vs round)
+
+    func test_compare_halfValueComponent_roundsNotTruncates() {
+        // The named-color database is built with round() (see toRGB8BitArray); the
+        // query must quantise the same way. 0.5 * 255 = 127.5 → round = 128,
+        // truncate = 127. With truncation the (0.5, 0.5, 0.5) query wrongly matches
+        // the [127] bucket, so the picked color is mis-named at every k.5/255 channel.
+        let cv = ClosestVector([[127, 127, 127], [128, 128, 128]])
+        let midGray = NSColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1).usingColorSpace(.sRGB)!
+        XCTAssertEqual(cv.compare(midGray), 1,
+                       "0.5-channel values must round (128) to match the database convention, not truncate (127)")
+    }
+
+    func test_compare_halfChannelAsymmetric_roundsNotTruncates() {
+        // Only the red channel sits on the 0.5 boundary (0.5 * 255 = 127.5 → round
+        // 128, truncate 127). Truncation wrongly matches the [127, 0, 0] bucket;
+        // rounding matches [128, 0, 0]. Locks the per-channel (non-gray) behaviour.
+        let cv = ClosestVector([[127, 0, 0], [128, 0, 0]])
+        let halfRed = NSColor(red: 0.5, green: 0.0, blue: 0.0, alpha: 1).usingColorSpace(.sRGB)!
+        XCTAssertEqual(cv.compare(halfRed), 1,
+                       "a single 0.5-channel must round to match the database convention")
+    }
 }


### PR DESCRIPTION
## Summary

`ClosestVector.compare` could return the wrong named color for any picked color whose channel values land on a `.5` 8-bit boundary, because the query was quantised by truncation while the named-color database is built by rounding.

## Root cause

`ClosestVector.compare` built its query array with `Int(component * 255)`, which truncates toward zero. The named-color database, however, is built with `NSColor.toRGB8BitArray()`, which **rounds**. At every `0.5`-channel boundary (`0.5 * 255 = 127.5`) the two sides of the nearest-neighbour search landed in different 8-bit buckets — the query sat in bucket `127` while the database entry sat in bucket `128` — so `getClosestColor` returned the wrong named color and disagreed with the rounded RGB readout shown elsewhere in the UI.

## Fix

Quantise the query with the **same** rounded helper used to build the database (`color.toRGB8BitArray()`), so the query and the database can never disagree on a bucket. This ties the query to the exact database convention rather than re-deriving the rounding, so the two cannot drift apart in future.

## Tests

Two regression cases in `ClosestVectorTests`:
- `test_compare_halfValueComponent_roundsNotTruncates` — a symmetric `(0.5, 0.5, 0.5)` gray must match the `[128]` bucket, not `[127]`.
- `test_compare_halfChannelAsymmetric_roundsNotTruncates` — a single channel on the `0.5` boundary (red `0.5`, others `0`) must round per-channel.

Both fail on the truncating implementation and pass after the fix.
