### PR TITLE
fix: make the minimum-OS update gate inclusive (>=), not strict (>)

### DIFF
--- a/Pika/Extensions/LatestAppStoreVersion+ShouldUpdate.swift
+++ b/Pika/Extensions/LatestAppStoreVersion+ShouldUpdate.swift
@@ -9,7 +9,7 @@ extension LatestAppStoreVersion {
         let versionString = "\(systemVersion.majorVersion).\(systemVersion.minorVersion).\(systemVersion.patchVersion)"
 
         let isRemoteVersionHigherThanLocal = currentVersion.compare(version, options: .numeric) == .orderedAscending
-        let isSystemVersionAllowed = versionString.compare(minimumOsVersion, options: .numeric) == .orderedDescending
+        let isSystemVersionAllowed = versionString.compare(minimumOsVersion, options: .numeric) != .orderedAscending
 
         return isRemoteVersionHigherThanLocal && isSystemVersionAllowed
     }


### PR DESCRIPTION
## Summary
`shouldUpdate` rejected users whose macOS version *exactly equaled* the release's `minimumOsVersion`: the minimum-OS gate used strict greater-than (`== .orderedDescending`), so the equal case (`.orderedSame`) was excluded.

## Root cause
`Pika/Extensions/LatestAppStoreVersion+ShouldUpdate.swift`:
```swift
let isSystemVersionAllowed = versionString.compare(minimumOsVersion, options: .numeric) == .orderedDescending
```
`== .orderedDescending` means `versionString > minimumOsVersion` (strict). A user whose macOS equals `minimumOsVersion` — a common case, since `minimumOsVersion` is typically a round value like `"12.0"` — fell into `.orderedSame` and was denied the update.

## Fix
Use `!= .orderedAscending` so equal-or-newer macOS is allowed:
```swift
let isSystemVersionAllowed = versionString.compare(minimumOsVersion, options: .numeric) != .orderedAscending
```
The remote-version check on the line above is correct and untouched.

## Notes
- No regression test is included: `LatestAppStoreVersion` is compiled only in the **Pika (Mac App Store)** target, while the test target links the main **Pika** target, so the type is not reachable from a unit test without an out-of-scope target restructure. The change is a single comparison operator, verifiable by inspection.
- While here I noticed `shouldUpdate`/`LookUpAPI` do not appear to be called anywhere in the current source; flagging in case this is intended for future wiring rather than live use.