### PR TITLE
Inline editable colours

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -55,7 +55,7 @@ jobs:
           fetch-depth: 1
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.3.app
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.3.app
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Resolve Swift packages
         run: |

--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		EA0C526025AB5A2B00AFF716 /* NavigationMenuItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C525F25AB5A2B00AFF716 /* NavigationMenuItems.swift */; };
 		EA0C526425AB5D1700AFF716 /* PikaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C526325AB5D1700AFF716 /* PikaWindow.swift */; };
 		EA0C526F25AB683400AFF716 /* EyedropperButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C526E25AB683400AFF716 /* EyedropperButton.swift */; };
+		DEC0FACE0000000000000022 /* EditableColorValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0FACE0000000000000020 /* EditableColorValue.swift */; };
 		EA136072284887E9004F1630 /* AppearanceButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA136071284887E9004F1630 /* AppearanceButtonStyle.swift */; };
 		EA257BD125D8629300C3FC54 /* SwapButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA257BD025D8629300C3FC54 /* SwapButtonStyle.swift */; };
 		EA424C7D25CDEF98009056A9 /* ComplianceToggleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA424C7C25CDEF98009056A9 /* ComplianceToggleGroup.swift */; };
@@ -162,6 +163,7 @@
 		EAE23DC52D032A38005BB270 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD0B6F3259CF29300FA2F67 /* AboutView.swift */; };
 		EAE23DC62D032A38005BB270 /* KeyboardShortcutKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA8AE1825B8EC070049299B /* KeyboardShortcutKey.swift */; };
 		EAE23DC72D032A38005BB270 /* EyedropperButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C526E25AB683400AFF716 /* EyedropperButton.swift */; };
+		DEC0FACE0000000000000023 /* EditableColorValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0FACE0000000000000020 /* EditableColorValue.swift */; };
 		EAE23DC82D032A38005BB270 /* MetalShader.metal in Sources */ = {isa = PBXBuildFile; fileRef = EA72BB8225A5334B008205E7 /* MetalShader.metal */; };
 		EAE23DC92D032A38005BB270 /* SwapButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA257BD025D8629300C3FC54 /* SwapButtonStyle.swift */; };
 		EAE23DCA2D032A38005BB270 /* NSWindowFade.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA72BBA825A7CE9C008205E7 /* NSWindowFade.swift */; };
@@ -287,6 +289,7 @@
 		EA0C525F25AB5A2B00AFF716 /* NavigationMenuItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationMenuItems.swift; sourceTree = "<group>"; };
 		EA0C526325AB5D1700AFF716 /* PikaWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PikaWindow.swift; sourceTree = "<group>"; };
 		EA0C526E25AB683400AFF716 /* EyedropperButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EyedropperButton.swift; sourceTree = "<group>"; };
+		DEC0FACE0000000000000020 /* EditableColorValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableColorValue.swift; sourceTree = "<group>"; };
 		EA0F36AE2929138E00BFC7EB /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
 		EA0F36B02929139000BFC7EB /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Main.strings; sourceTree = "<group>"; };
 		EA136071284887E9004F1630 /* AppearanceButtonStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppearanceButtonStyle.swift; sourceTree = "<group>"; };
@@ -585,6 +588,7 @@
 			children = (
 				EA635DE025B4FC580014D91A /* ColorPickers.swift */,
 				EA0C526E25AB683400AFF716 /* EyedropperButton.swift */,
+				DEC0FACE0000000000000020 /* EditableColorValue.swift */,
 				EA635DE925B534C80014D91A /* EyedropperItem.swift */,
 			);
 			name = Eyedropper;
@@ -995,6 +999,7 @@
 				CC000001000000000000AB11 /* CGFloat+Format.swift in Sources */,
 				EAA8AE1925B8EC070049299B /* KeyboardShortcutKey.swift in Sources */,
 				EA0C526F25AB683400AFF716 /* EyedropperButton.swift in Sources */,
+				DEC0FACE0000000000000022 /* EditableColorValue.swift in Sources */,
 				EA72BB8425A5334B008205E7 /* MetalShader.metal in Sources */,
 				EA257BD125D8629300C3FC54 /* SwapButtonStyle.swift in Sources */,
 				EA72BBA925A7CE9C008205E7 /* NSWindowFade.swift in Sources */,
@@ -1087,6 +1092,7 @@
 				EAE23DC62D032A38005BB270 /* KeyboardShortcutKey.swift in Sources */,
 				F8ABAC5B2EAAD0DF008CD152 /* ColorPickOverlay.swift in Sources */,
 				EAE23DC72D032A38005BB270 /* EyedropperButton.swift in Sources */,
+				DEC0FACE0000000000000023 /* EditableColorValue.swift in Sources */,
 				EAE23DC82D032A38005BB270 /* MetalShader.metal in Sources */,
 				EAE2EB9F2D03C3DE00FA9BC9 /* LookUpAPI.swift in Sources */,
 				EAE23DC92D032A38005BB270 /* SwapButtonStyle.swift in Sources */,

--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		CC2000000000000000000901 /* NotificationNamesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000900 /* NotificationNamesTests.swift */; };
 		CC2000000000000000000A01 /* CGFloatFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000A00 /* CGFloatFormatTests.swift */; };
 		CC2000000000000000000B01 /* ColorPairTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000B00 /* ColorPairTests.swift */; };
+		DEC0FACE0000000000000011 /* ColorDecompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0FACE0000000000000010 /* ColorDecompositionTests.swift */; };
 		CC2000000000000000000C01 /* ClosestVectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000C00 /* ClosestVectorTests.swift */; };
 		CC2000000000000000000D01 /* SequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000D00 /* SequenceTests.swift */; };
 		CC2000000000000000000E01 /* ExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2000000000000000000E00 /* ExporterTests.swift */; };
@@ -63,6 +64,8 @@
 		CC000001000000000000AB12 /* CGFloat+Format.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000001000000000000AB10 /* CGFloat+Format.swift */; };
 		EA03E39B2F5E618E00998D8B /* ColorPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA03E39A2F5E618E00998D8B /* ColorPair.swift */; };
 		EA03E39C2F5E618E00998D8B /* ColorPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA03E39A2F5E618E00998D8B /* ColorPair.swift */; };
+		DEC0FACE0000000000000002 /* ColorDecomposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0FACE0000000000000001 /* ColorDecomposition.swift */; };
+		DEC0FACE0000000000000003 /* ColorDecomposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC0FACE0000000000000001 /* ColorDecomposition.swift */; };
 		EA03E39E2F5E619800998D8B /* ColorHistoryDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA03E39D2F5E619800998D8B /* ColorHistoryDrawer.swift */; };
 		5A49CEF4F87747CDB61A3CBD /* PaletteComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35086BCEF529498582A432A1 /* PaletteComponents.swift */; };
 		EA03E39F2F5E619800998D8B /* ColorHistoryDrawer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA03E39D2F5E619800998D8B /* ColorHistoryDrawer.swift */; };
@@ -240,6 +243,7 @@
 		CC2000000000000000000900 /* NotificationNamesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationNamesTests.swift; sourceTree = "<group>"; };
 		CC2000000000000000000A00 /* CGFloatFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGFloatFormatTests.swift; sourceTree = "<group>"; };
 		CC2000000000000000000B00 /* ColorPairTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPairTests.swift; sourceTree = "<group>"; };
+		DEC0FACE0000000000000010 /* ColorDecompositionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorDecompositionTests.swift; sourceTree = "<group>"; };
 		CC2000000000000000000C00 /* ClosestVectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosestVectorTests.swift; sourceTree = "<group>"; };
 		CC2000000000000000000D00 /* SequenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceTests.swift; sourceTree = "<group>"; };
 		CC2000000000000000000E00 /* ExporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExporterTests.swift; sourceTree = "<group>"; };
@@ -275,6 +279,7 @@
 		CC000001000000000000AB00 /* NSColor+RGB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSColor+RGB.swift"; sourceTree = "<group>"; };
 		CC000001000000000000AB10 /* CGFloat+Format.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGFloat+Format.swift"; sourceTree = "<group>"; };
 		EA03E39A2F5E618E00998D8B /* ColorPair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPair.swift; sourceTree = "<group>"; };
+		DEC0FACE0000000000000001 /* ColorDecomposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorDecomposition.swift; sourceTree = "<group>"; };
 		EA03E39D2F5E619800998D8B /* ColorHistoryDrawer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorHistoryDrawer.swift; sourceTree = "<group>"; };
 		35086BCEF529498582A432A1 /* PaletteComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaletteComponents.swift; sourceTree = "<group>"; };
 		EA03E3A02F5E619800998D8B /* ColorPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPreview.swift; sourceTree = "<group>"; };
@@ -505,6 +510,7 @@
 			isa = PBXGroup;
 			children = (
 				EA03E39A2F5E618E00998D8B /* ColorPair.swift */,
+				DEC0FACE0000000000000001 /* ColorDecomposition.swift */,
 				CCB1CA0000000000000000F1 /* ColorPickSession.swift */,
 				CCB1CA0000000000000000F4 /* CustomColorPickSession.swift */,
 				CC1100000000000000000007 /* Models */,
@@ -565,6 +571,7 @@
 				CC2000000000000000000900 /* NotificationNamesTests.swift */,
 				CC2000000000000000000A00 /* CGFloatFormatTests.swift */,
 				CC2000000000000000000B00 /* ColorPairTests.swift */,
+				DEC0FACE0000000000000010 /* ColorDecompositionTests.swift */,
 				CC2000000000000000000C00 /* ClosestVectorTests.swift */,
 				CC2000000000000000000D00 /* SequenceTests.swift */,
 				CC2000000000000000000E00 /* ExporterTests.swift */,
@@ -964,6 +971,7 @@
 				EAF100CD25C785C4006E1EC3 /* TouchBarVisual.swift in Sources */,
 				EA801285259F8F480026D5D9 /* ComplianceToggle.swift in Sources */,
 				EA03E39B2F5E618E00998D8B /* ColorPair.swift in Sources */,
+				DEC0FACE0000000000000002 /* ColorDecomposition.swift in Sources */,
 				221600FD25A636D600B8B7D9 /* ConditionalModifier.swift in Sources */,
 				EA03E39E2F5E619800998D8B /* ColorHistoryDrawer.swift in Sources */,
 				5A49CEF4F87747CDB61A3CBD /* PaletteComponents.swift in Sources */,
@@ -1050,6 +1058,7 @@
 				EAE23DB12D032A38005BB270 /* AppModeToggleGroup.swift in Sources */,
 				EAE23DB22D032A38005BB270 /* Visualisation.swift in Sources */,
 				EA03E39C2F5E618E00998D8B /* ColorPair.swift in Sources */,
+				DEC0FACE0000000000000003 /* ColorDecomposition.swift in Sources */,
 				EAE23DB32D032A38005BB270 /* ContentView.swift in Sources */,
 				EAE23DB42D032A38005BB270 /* AppDelegate.swift in Sources */,
 				CCFEED0003000000000000A3 /* PikaApp.swift in Sources */,
@@ -1116,6 +1125,7 @@
 				CC2000000000000000000901 /* NotificationNamesTests.swift in Sources */,
 				CC2000000000000000000A01 /* CGFloatFormatTests.swift in Sources */,
 				CC2000000000000000000B01 /* ColorPairTests.swift in Sources */,
+				DEC0FACE0000000000000011 /* ColorDecompositionTests.swift in Sources */,
 				CC2000000000000000000C01 /* ClosestVectorTests.swift in Sources */,
 				CC2000000000000000000D01 /* SequenceTests.swift in Sources */,
 				CC2000000000000000000E01 /* ExporterTests.swift in Sources */,

--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -1511,7 +1511,7 @@
 			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.0;
+				minimumVersion = 2.0.0;
 			};
 		};
 		EAD0B6E7259CEF8600FA2F67 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/Pika.xcodeproj/project.pbxproj
+++ b/Pika.xcodeproj/project.pbxproj
@@ -1511,7 +1511,7 @@
 			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				minimumVersion = 2.4.0;
 			};
 		};
 		EAD0B6E7259CEF8600FA2F67 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/Pika.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pika.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "49c3fc04ea827f816df67843bfcc57286b47ff06",
-        "version" : "3.0.1"
+        "revision" : "045cf174010beb335fa1d2567d18c057b8787165",
+        "version" : "2.3.0"
       }
     },
     {

--- a/Pika.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Pika.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/KeyboardShortcuts",
       "state" : {
-        "revision" : "045cf174010beb335fa1d2567d18c057b8787165",
-        "version" : "2.3.0"
+        "revision" : "1aef85578fdd4f9eaeeb8d53b7b4fc31bf08fe27",
+        "version" : "2.4.0"
       }
     },
     {

--- a/Pika/AppDelegate.swift
+++ b/Pika/AppDelegate.swift
@@ -112,10 +112,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    // KeyboardShortcuts 3.x isolates `onKeyUp(for:action:)` to the main actor, so this
-    // registration must run there too. Its only caller, `applicationDidFinishLaunching`,
-    // is already main-actor isolated.
-    @MainActor
     private func registerTogglePikaShortcut() {
         KeyboardShortcuts.onKeyUp(for: .togglePika) { [] in
             if Defaults[.viewedSplash] {

--- a/Pika/Assets/en.lproj/Localizable.strings
+++ b/Pika/Assets/en.lproj/Localizable.strings
@@ -202,6 +202,9 @@
 /* Background */
 "color.background" = "Background";
 
+/* Invalid input */
+"color.edit.invalid" = "Invalid input";
+
 /* WCAG 3:1 */
 "color.wcag.30" = "WCAG 2 level AA requires a contrast ratio of at least 3:1 for large (18pt / ~24px) or bold (14pt / ~18.6px) text, and for non-text content like UI.";
 

--- a/Pika/Constants/PikaText.swift
+++ b/Pika/Constants/PikaText.swift
@@ -16,6 +16,7 @@ enum PikaText {
 
     static let textColorForeground = NSLocalizedString("color.foreground", comment: "Foreground")
     static let textColorBackground = NSLocalizedString("color.background", comment: "Background")
+    static let textColorEditInvalid = NSLocalizedString("color.edit.invalid", comment: "Invalid input")
     static let textColorPass = NSLocalizedString("color.wcag.pass", comment: "Pass")
     static let textColorFail = NSLocalizedString("color.wcag.fail", comment: "Fail")
     static let textColorRatio = NSLocalizedString("color.ratio", comment: "Contrast Ratio")

--- a/Pika/Extensions/NSColor+HSL.swift
+++ b/Pika/Extensions/NSColor+HSL.swift
@@ -138,6 +138,71 @@ extension NSColor {
         let hslString = NSString(format: formatString, hue, saturation, lightness)
         return hslString as String
     }
+
+    /*
+     * Inverses (string/component → colour)
+     *
+     * These are the inverses of `toHSBComponents` / `toHSLComponents` and take the same
+     * normalised units (h, s, b/l all in 0…1). They build the colour directly in `colorSpace`
+     * — the same space the forward conversions read from — so a decompose→recompose round-trip
+     * lands on the same colour (±1 in the display units, from integer rounding).
+     */
+
+    /// Build a colour from HSB/HSV components (all in 0…1), in `colorSpace`.
+    static func fromHSB(
+        h: CGFloat, s: CGFloat, b: CGFloat,
+        in colorSpace: NSColorSpace = Defaults[.colorSpace]
+    ) -> NSColor {
+        let v = b
+        guard s > 0 else {
+            return NSColor(colorSpace: colorSpace, components: [v, v, v, 1], count: 4)
+        }
+
+        let hue = (h.truncatingRemainder(dividingBy: 1) + 1).truncatingRemainder(dividingBy: 1) * 6
+        let i = floor(hue)
+        let f = hue - i
+        let p = v * (1 - s)
+        let q = v * (1 - s * f)
+        let t = v * (1 - s * (1 - f))
+
+        let r, g, bl: CGFloat
+        switch Int(i) % 6 {
+        case 0: (r, g, bl) = (v, t, p)
+        case 1: (r, g, bl) = (q, v, p)
+        case 2: (r, g, bl) = (p, v, t)
+        case 3: (r, g, bl) = (p, q, v)
+        case 4: (r, g, bl) = (t, p, v)
+        default: (r, g, bl) = (v, p, q)
+        }
+        return NSColor(colorSpace: colorSpace, components: [r, g, bl, 1], count: 4)
+    }
+
+    /// Build a colour from HSL components (all in 0…1), in `colorSpace`.
+    static func fromHSL(
+        h: CGFloat, s: CGFloat, l: CGFloat,
+        in colorSpace: NSColorSpace = Defaults[.colorSpace]
+    ) -> NSColor {
+        guard s > 0 else {
+            return NSColor(colorSpace: colorSpace, components: [l, l, l, 1], count: 4)
+        }
+
+        func hue2rgb(_ p: CGFloat, _ q: CGFloat, _ t: CGFloat) -> CGFloat {
+            var t = t
+            if t < 0 { t += 1 }
+            if t > 1 { t -= 1 }
+            if t < 1 / 6 { return p + (q - p) * 6 * t }
+            if t < 1 / 2 { return q }
+            if t < 2 / 3 { return p + (q - p) * (2 / 3 - t) * 6 }
+            return p
+        }
+
+        let q = l < 0.5 ? l * (1 + s) : l + s - l * s
+        let p = 2 * l - q
+        let r = hue2rgb(p, q, h + 1 / 3)
+        let g = hue2rgb(p, q, h)
+        let b = hue2rgb(p, q, h - 1 / 3)
+        return NSColor(colorSpace: colorSpace, components: [r, g, b, 1], count: 4)
+    }
 }
 
 // swiftlint:enable identifier_name

--- a/Pika/Extensions/NSColor+Hex.swift
+++ b/Pika/Extensions/NSColor+Hex.swift
@@ -14,7 +14,8 @@ extension NSColor {
         in colorSpace: NSColorSpace = Defaults[.colorSpace],
         alpha: CGFloat = 1
     ) -> NSColor? {
-        var stripped = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        let trimmed = hex.trimmingCharacters(in: .whitespaces)
+        var stripped = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
         guard stripped.count == 3 || stripped.count == 6,
               stripped.allSatisfy(\.isHexDigit) else { return nil }
 
@@ -40,8 +41,8 @@ extension NSColor {
         return UInt32(rounded)
     }
 
-    func toHex() -> UInt32 {
-        let rgba = toRGBAComponents()
+    func toHex(in colorSpace: NSColorSpace = Defaults[.colorSpace]) -> UInt32 {
+        let rgba = toRGBAComponents(in: colorSpace)
         return roundToHex(rgba.r) << 16 | roundToHex(rgba.g) << 8 | roundToHex(rgba.b)
     }
 

--- a/Pika/Extensions/NSColor+Hex.swift
+++ b/Pika/Extensions/NSColor+Hex.swift
@@ -1,6 +1,39 @@
 import Cocoa
+import Defaults
 
 extension NSColor {
+    /// Parse a hex string into a colour, or `nil` if it isn't valid hex.
+    ///
+    /// Accepts 3 or 6 hex digits, case-insensitive, with or without a leading `#`.
+    /// This is the one validating hex parser — unlike the `init(hex:)` convenience
+    /// init it never falls back to a colour, so callers (live editing, etc.) can tell
+    /// valid input from invalid. Builds in `colorSpace` so a value read back via
+    /// `toHexString()` (which reads `Defaults[.colorSpace]`) round-trips exactly.
+    static func fromHex(
+        _ hex: String,
+        in colorSpace: NSColorSpace = Defaults[.colorSpace],
+        alpha: CGFloat = 1
+    ) -> NSColor? {
+        var stripped = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        guard stripped.count == 3 || stripped.count == 6,
+              stripped.allSatisfy(\.isHexDigit) else { return nil }
+
+        if stripped.count == 3 {
+            stripped = stripped.map { "\($0)\($0)" }.joined()
+        }
+
+        var rgb: UInt64 = 0
+        guard Scanner(string: stripped).scanHexInt64(&rgb) else { return nil }
+
+        let components: [CGFloat] = [
+            CGFloat((rgb >> 16) & 0xFF) / 255,
+            CGFloat((rgb >> 8) & 0xFF) / 255,
+            CGFloat(rgb & 0xFF) / 255,
+            alpha,
+        ]
+        return NSColor(colorSpace: colorSpace, components: components, count: 4)
+    }
+
     func roundToHex(_ value: CGFloat) -> UInt32 {
         guard value > 0 else { return 0 }
         let rounded: CGFloat = round(value * 255.0)

--- a/Pika/Extensions/NSColor+Init.swift
+++ b/Pika/Extensions/NSColor+Init.swift
@@ -17,32 +17,19 @@ extension NSColor {
      - parameter hex:     The hex color, i.e. "FF0072" or "#FF0072".
      - parameter alpha:   The opacity of the color, value between [0,1]. Optional. Default: 1
 
-     Invalid input (wrong length) falls back to black rather than crashing — this is fed
-     remote and user-facing strings (URL schemes, fetched colour lists).
+     Invalid input falls back to black rather than crashing — this is fed remote and
+     user-facing strings (URL schemes, colour lists). Callers that need to *reject*
+     invalid input should use the failable `NSColor.fromHex(_:)` instead.
      */
     convenience init(hex: String, alpha: CGFloat = 1) {
-        var hex = hex.replacingOccurrences(of: "#", with: "")
-
-        guard hex.count == 3 || hex.count == 6 else {
-            self.init(red: 0, green: 0, blue: 0, alpha: alpha)
-            return
-        }
-
-        if hex.count == 3 {
-            let tmp = hex
-            hex = ""
-            for char in tmp {
-                hex += String([char, char])
-            }
-        }
-
-        let scanner = Scanner(string: hex)
-        var rgb: UInt64 = 0
-        scanner.scanHexInt64(&rgb)
-
-        let red = CGFloat((rgb >> 16) & 0xFF) / 255
-        let green = CGFloat((rgb >> 8) & 0xFF) / 255
-        let blue = CGFloat(rgb & 0xFF) / 255
-        self.init(red: red, green: green, blue: blue, alpha: alpha)
+        let parsed = NSColor.fromHex(hex, in: .sRGB, alpha: alpha)
+            ?? NSColor(colorSpace: .sRGB, components: [0, 0, 0, alpha], count: 4)
+        // `parsed` is already in sRGB, so its components read back without conversion.
+        self.init(
+            srgbRed: parsed.redComponent,
+            green: parsed.greenComponent,
+            blue: parsed.blueComponent,
+            alpha: parsed.alphaComponent
+        )
     }
 }

--- a/Pika/Extensions/NSColor+Lab.swift
+++ b/Pika/Extensions/NSColor+Lab.swift
@@ -14,6 +14,15 @@ extension NSColor {
         c <= 0.04045 ? c / 12.92 : pow((c + 0.055) / 1.055, 2.4)
     }
 
+    // Inverse of `linearizeSRGB`: gamma-encode a linear-light component, clamped to [0, 1].
+    // Lab and OKLCH can express colours outside the sRGB gamut, so the clamp snaps those
+    // to the nearest displayable channel value (see the round-trip note in the plan).
+    private static func encodeSRGB(_ c: CGFloat) -> CGFloat {
+        let clamped = Swift.min(Swift.max(c, 0), 1)
+        let encoded = clamped <= 0.0031308 ? 12.92 * clamped : 1.055 * pow(clamped, 1 / 2.4) - 0.055
+        return Swift.min(Swift.max(encoded, 0), 1)
+    }
+
     /*
      * OpenGL
      */
@@ -140,6 +149,75 @@ extension NSColor {
         case .unformatted:
             return "\(l_str), \(c_str), \(h_str)"
         }
+    }
+
+    /*
+     * Inverses (component → colour)
+     *
+     * Inverses of `toLabComponents` / `toOklchComponents`, taking the same units the forward
+     * conversions produce (Lab: L 0…100, a/b unbounded; OKLCH: L 0…1, C ≥ 0, H in degrees).
+     * Both forward conversions are defined via the sRGB path, so these build in sRGB. Out-of-gamut
+     * inputs are clamped per channel (see `encodeSRGB`), so a round-trip on an out-of-gamut colour
+     * snaps to the nearest displayable one — inherent to storing sRGB.
+     */
+
+    /// Build an sRGB colour from CIE-Lab components (L in 0…100, a/b in Lab units).
+    static func fromLab(l: CGFloat, a: CGFloat, b: CGFloat) -> NSColor {
+        // Lab → XYZ (D65 reference white), inverse of the forward f().
+        let Xn: CGFloat = 0.95047
+        let Yn: CGFloat = 1.00000
+        let Zn: CGFloat = 1.08883
+        let delta: CGFloat = 6.0 / 29.0
+
+        func fInv(_ t: CGFloat) -> CGFloat {
+            t > delta ? pow(t, 3) : 3 * pow(delta, 2) * (t - 4.0 / 29.0)
+        }
+
+        let fy = (l + 16) / 116
+        let fx = fy + a / 500
+        let fz = fy - b / 200
+
+        let x = Xn * fInv(fx)
+        let y = Yn * fInv(fy)
+        let z = Zn * fInv(fz)
+
+        // XYZ → linear sRGB
+        let r_lin = x * 3.2404542 - y * 1.5371385 - z * 0.4985314
+        let g_lin = x * -0.9692660 + y * 1.8760108 + z * 0.0415560
+        let b_lin = x * 0.0556434 - y * 0.2040259 + z * 1.0572252
+
+        return NSColor(
+            colorSpace: .sRGB,
+            components: [encodeSRGB(r_lin), encodeSRGB(g_lin), encodeSRGB(b_lin), 1],
+            count: 4
+        )
+    }
+
+    /// Build an sRGB colour from OKLCH components (L in 0…1, C ≥ 0, H in degrees).
+    static func fromOklch(l: CGFloat, c: CGFloat, h: CGFloat) -> NSColor {
+        let hRad = h * .pi / 180
+        let a = c * cos(hRad)
+        let b = c * sin(hRad)
+
+        // OKLCH → OKLab → LMS' → LMS (inverse of the forward M2/M1 matrices).
+        let l_ = l + 0.3963377774 * a + 0.2158037573 * b
+        let m_ = l - 0.1055613458 * a - 0.0638541728 * b
+        let s_ = l - 0.0894841775 * a - 1.2914855480 * b
+
+        let lCube = l_ * l_ * l_
+        let mCube = m_ * m_ * m_
+        let sCube = s_ * s_ * s_
+
+        // LMS → linear sRGB
+        let r_lin = lCube * 4.0767416621 - mCube * 3.3077115913 + sCube * 0.2309699292
+        let g_lin = lCube * -1.2684380046 + mCube * 2.6097574011 - sCube * 0.3413193965
+        let b_lin = lCube * -0.0041960863 - mCube * 0.7034186147 + sCube * 1.7076147010
+
+        return NSColor(
+            colorSpace: .sRGB,
+            components: [encodeSRGB(r_lin), encodeSRGB(g_lin), encodeSRGB(b_lin), 1],
+            count: 4
+        )
     }
 }
 

--- a/Pika/Services/ColorDecomposition.swift
+++ b/Pika/Services/ColorDecomposition.swift
@@ -27,14 +27,17 @@ struct ColorComponent: Equatable {
         case .hex:
             return NSColor.fromHex(trimmed) != nil
         case .integer:
-            // Reject decimals/exponents for integer fields; only a plain whole number.
-            guard let n = Int(trimmed) else { return false }
-            return range.map { $0.contains(Double(n)) } ?? true
+            // Reject decimals/exponents for integer fields; only a plain whole number. A
+            // number outside `range` is still valid input, not rejected — it's clamped to the
+            // nearest bound on commit (see `EditableColorValue.clampValuesToRange`), matching
+            // `recompose`'s own clamping rather than reverting the whole edit.
+            return Int(trimmed) != nil
         case .decimal:
             // `Double("inf")`/`Double("nan")` parse successfully but aren't valid colour
-            // values, and a nil range (e.g. Lab a/b) wouldn't otherwise reject them.
-            guard let n = Double(trimmed), n.isFinite else { return false }
-            return range.map { $0.contains(n) } ?? true
+            // values, and a nil range (e.g. Lab a/b) wouldn't otherwise reject them. As with
+            // `.integer`, a finite out-of-range number is valid input — clamped on commit.
+            guard let n = Double(trimmed) else { return false }
+            return n.isFinite
         }
     }
 }

--- a/Pika/Services/ColorDecomposition.swift
+++ b/Pika/Services/ColorDecomposition.swift
@@ -31,7 +31,9 @@ struct ColorComponent: Equatable {
             guard let n = Int(trimmed) else { return false }
             return range.map { $0.contains(Double(n)) } ?? true
         case .decimal:
-            guard let n = Double(trimmed) else { return false }
+            // `Double("inf")`/`Double("nan")` parse successfully but aren't valid colour
+            // values, and a nil range (e.g. Lab a/b) wouldn't otherwise reject them.
+            guard let n = Double(trimmed), n.isFinite else { return false }
             return range.map { $0.contains(n) } ?? true
         }
     }
@@ -65,7 +67,7 @@ extension ColorFormat {
     func decompose(_ color: NSColor, style: CopyFormat, in cs: NSColorSpace) -> DecomposedColor {
         switch self {
         case .hex:
-            let digits = String(format: "%06x", color.toHex())
+            let digits = String(format: "%06x", color.toHex(in: cs))
             return DecomposedColor(
                 leading: style == .css ? "#" : "",
                 components: [ColorComponent(value: digits, kind: .hex, range: nil)],

--- a/Pika/Services/ColorDecomposition.swift
+++ b/Pika/Services/ColorDecomposition.swift
@@ -1,0 +1,306 @@
+import Cocoa
+import Defaults
+
+// swiftlint:disable identifier_name
+// identifier_name is disabled because colour-component math uses conventional single-letter
+// names (r, g, b, h, s, l, a) that would be misleading if renamed.
+
+/// How a single editable component is validated and parsed.
+enum ComponentKind: Equatable {
+    case hex // 3 or 6 hex digits
+    case integer // whole number in `range`
+    case decimal // decimal number in `range` (nil range = unbounded, e.g. Lab a/b)
+}
+
+/// One editable number (or hex string) inside a formatted colour value.
+struct ColorComponent: Equatable {
+    var value: String
+    var kind: ComponentKind
+    var range: ClosedRange<Double>?
+
+    /// Whether `candidate` is a valid value for this component's kind and range.
+    /// This is what the editable field uses to drive its valid/invalid state.
+    func isValid(_ candidate: String) -> Bool {
+        let trimmed = candidate.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return false }
+        switch kind {
+        case .hex:
+            return NSColor.fromHex(trimmed) != nil
+        case .integer:
+            // Reject decimals/exponents for integer fields; only a plain whole number.
+            guard let n = Int(trimmed) else { return false }
+            return range.map { $0.contains(Double(n)) } ?? true
+        case .decimal:
+            guard let n = Double(trimmed) else { return false }
+            return range.map { $0.contains(n) } ?? true
+        }
+    }
+}
+
+/// A formatted colour value split into fixed scaffolding + editable components.
+///
+/// Invariant: `joined()` equals `color.toFormat(format:style:)` for the colour it was
+/// decomposed from — the editable readout renders the same text as the read-only one.
+struct DecomposedColor: Equatable {
+    var leading: String
+    var components: [ColorComponent]
+    var separators: [String] // between components; count == components.count - 1
+    var trailing: String
+
+    var values: [String] { components.map(\.value) }
+
+    func joined() -> String {
+        var result = leading
+        for (i, comp) in components.enumerated() {
+            result += comp.value
+            if i < separators.count { result += separators[i] }
+        }
+        return result + trailing
+    }
+}
+
+extension ColorFormat {
+    /// Split a colour into fixed scaffolding + editable components for `(self, style)`.
+    /// Mirrors the matching `to…String` formatter exactly (see `joined()` invariant).
+    func decompose(_ color: NSColor, style: CopyFormat, in cs: NSColorSpace) -> DecomposedColor {
+        switch self {
+        case .hex:
+            let digits = String(format: "%06x", color.toHex())
+            return DecomposedColor(
+                leading: style == .css ? "#" : "",
+                components: [ColorComponent(value: digits, kind: .hex, range: nil)],
+                separators: [],
+                trailing: ""
+            )
+
+        case .rgb:
+            let rgb = color.toRGBAComponents(in: cs)
+            switch style {
+            case .swiftUI:
+                return DecomposedColor(
+                    leading: "Color(red: ",
+                    components: floatComponents([rgb.r, rgb.g, rgb.b], range: 0 ... 1),
+                    separators: [", green: ", ", blue: "],
+                    trailing: ")"
+                )
+            default:
+                let comps = int255Components([rgb.r, rgb.g, rgb.b])
+                return DecomposedColor(
+                    leading: style == .unformatted ? "" : "rgb(",
+                    components: comps,
+                    separators: [", ", ", "],
+                    trailing: style == .unformatted ? "" : ")"
+                )
+            }
+
+        case .opengl:
+            let rgb = color.toRGBAComponents(in: cs)
+            let comps = [rgb.r, rgb.g, rgb.b].map {
+                ColorComponent(value: openGLValueString($0), kind: .decimal, range: 0 ... 1)
+            }
+            return DecomposedColor(
+                leading: style == .unformatted ? "" : "rgba(",
+                components: comps,
+                separators: [", ", ", "],
+                trailing: style == .unformatted ? ", 1.0" : ", 1.0)"
+            )
+
+        case .hsb:
+            let hsb = color.toHSBComponents()
+            switch style {
+            case .swiftUI:
+                return DecomposedColor(
+                    leading: "Color(hue: ",
+                    components: floatComponents([hsb.h, hsb.s, hsb.b], range: 0 ... 1),
+                    separators: [", saturation: ", ", brightness: "],
+                    trailing: ")"
+                )
+            case .css:
+                return DecomposedColor(
+                    leading: "hsb(",
+                    components: angleAndPercents(h: hsb.h, [hsb.s, hsb.b]),
+                    separators: [", ", "%, "],
+                    trailing: "%)"
+                )
+            default:
+                return DecomposedColor(
+                    leading: style == .unformatted ? "" : "hsb(",
+                    components: angleAndPercents(h: hsb.h, [hsb.s, hsb.b]),
+                    separators: [", ", ", "],
+                    trailing: style == .unformatted ? "" : ")"
+                )
+            }
+
+        case .hsl:
+            let hsl = color.toHSLComponents()
+            let comps = angleAndPercents(h: hsl.h, [hsl.s, hsl.l])
+            switch style {
+            case .css:
+                return DecomposedColor(
+                    leading: "hsl(", components: comps, separators: [", ", "%, "], trailing: "%)"
+                )
+            case .unformatted:
+                return DecomposedColor(
+                    leading: "", components: comps, separators: [", ", ", "], trailing: ""
+                )
+            default: // design, swiftUI both render "hsl(%d, %d, %d)"
+                return DecomposedColor(
+                    leading: "hsl(", components: comps, separators: [", ", ", "], trailing: ")"
+                )
+            }
+
+        case .lab:
+            let lab = color.toLabComponents()
+            let comps = [
+                labComponent(lab.l, range: 0 ... 100),
+                labComponent(lab.a, range: nil),
+                labComponent(lab.b, range: nil),
+            ]
+            switch style {
+            case .css:
+                return DecomposedColor(
+                    leading: "lab(", components: comps, separators: [" ", " "], trailing: ")"
+                )
+            case .unformatted:
+                return DecomposedColor(
+                    leading: "", components: comps, separators: [", ", ", "], trailing: ""
+                )
+            default:
+                return DecomposedColor(
+                    leading: "lab(", components: comps, separators: [", ", ", "], trailing: ")"
+                )
+            }
+
+        case .oklch:
+            let oklch = color.toOklchComponents()
+            // L is shown as a 0–100 percentage-magnitude in every style; only css appends "%".
+            let comps = [
+                ColorComponent(
+                    value: (round(oklch.l * 10000) / 100).strippedDecimalString(maxDecimalPlaces: 2),
+                    kind: .decimal, range: 0 ... 100
+                ),
+                ColorComponent(
+                    value: (round(oklch.c * 10000) / 10000).strippedDecimalString(maxDecimalPlaces: 4),
+                    kind: .decimal, range: 0 ... 1
+                ),
+                ColorComponent(
+                    value: (round(oklch.h * 100) / 100).strippedDecimalString(maxDecimalPlaces: 2),
+                    kind: .decimal, range: 0 ... 360
+                ),
+            ]
+            switch style {
+            case .css:
+                return DecomposedColor(
+                    leading: "oklch(", components: comps, separators: ["% ", " "], trailing: ")"
+                )
+            case .unformatted:
+                return DecomposedColor(
+                    leading: "", components: comps, separators: [", ", ", "], trailing: ""
+                )
+            default:
+                return DecomposedColor(
+                    leading: "oklch(", components: comps, separators: [", ", ", "], trailing: ")"
+                )
+            }
+        }
+    }
+
+    /// Rebuild an sRGB-normalisable colour from edited component strings, or `nil` if any is
+    /// unparseable. Assumes per-component validity has already been checked by the field; still
+    /// clamps into range so a committed colour is always displayable.
+    func recompose(_ values: [String], style: CopyFormat, in cs: NSColorSpace) -> NSColor? {
+        switch self {
+        case .hex:
+            guard values.count == 1 else { return nil }
+            return NSColor.fromHex(values[0], in: cs)
+
+        case .rgb:
+            guard let triple = doubles(values, count: 3) else { return nil }
+            let rgb: [CGFloat]
+            if style == .swiftUI {
+                rgb = triple.map { clamp($0, 0, 1) }
+            } else {
+                rgb = triple.map { clamp($0, 0, 255) / 255 }
+            }
+            return NSColor(colorSpace: cs, components: rgb + [1], count: 4)
+
+        case .opengl:
+            guard let triple = doubles(values, count: 3) else { return nil }
+            let rgb = triple.map { clamp($0, 0, 1) }
+            return NSColor(colorSpace: cs, components: rgb + [1], count: 4)
+
+        case .hsb:
+            guard let triple = doubles(values, count: 3) else { return nil }
+            let (h, s, b): (CGFloat, CGFloat, CGFloat)
+            if style == .swiftUI {
+                (h, s, b) = (clamp(triple[0], 0, 1), clamp(triple[1], 0, 1), clamp(triple[2], 0, 1))
+            } else {
+                (h, s, b) = (clamp(triple[0], 0, 360) / 360, clamp(triple[1], 0, 100) / 100, clamp(triple[2], 0, 100) / 100)
+            }
+            return NSColor.fromHSB(h: h, s: s, b: b, in: cs)
+
+        case .hsl:
+            guard let triple = doubles(values, count: 3) else { return nil }
+            let h = clamp(triple[0], 0, 360) / 360
+            let s = clamp(triple[1], 0, 100) / 100
+            let l = clamp(triple[2], 0, 100) / 100
+            return NSColor.fromHSL(h: h, s: s, l: l, in: cs)
+
+        case .lab:
+            guard let triple = doubles(values, count: 3) else { return nil }
+            return NSColor.fromLab(l: triple[0], a: triple[1], b: triple[2])
+
+        case .oklch:
+            guard let triple = doubles(values, count: 3) else { return nil }
+            return NSColor.fromOklch(l: triple[0] / 100, c: triple[1], h: triple[2])
+        }
+    }
+}
+
+// MARK: - Private formatting/parsing helpers
+
+private func int255Components(_ channels: [CGFloat]) -> [ColorComponent] {
+    channels.map { ColorComponent(value: String(Int(round($0 * 255))), kind: .integer, range: 0 ... 255) }
+}
+
+private func floatComponents(_ channels: [CGFloat], range: ClosedRange<Double>) -> [ColorComponent] {
+    channels.map { ColorComponent(value: String(format: "%.5g", $0), kind: .decimal, range: range) }
+}
+
+/// Hue (0–360 integer) followed by two 0–100 integer percentages (S/B or S/L).
+private func angleAndPercents(h: CGFloat, _ rest: [CGFloat]) -> [ColorComponent] {
+    let hue = ColorComponent(value: String(Int(round(h * 360))), kind: .integer, range: 0 ... 360)
+    let percents = rest.map {
+        ColorComponent(value: String(Int(round($0 * 100))), kind: .integer, range: 0 ... 100)
+    }
+    return [hue] + percents
+}
+
+/// Matches `toOpenGLString`'s ".0"-appended `%.5g`, e.g. 0 → "0.0", 1 → "1.0", 0.5 → "0.5".
+private func openGLValueString(_ value: CGFloat) -> String {
+    let s = String(format: "%.5g", value)
+    return s.contains(".") ? s : "\(s).0"
+}
+
+private func labComponent(_ value: CGFloat, range: ClosedRange<Double>?) -> ColorComponent {
+    ColorComponent(
+        value: (round(value * 100) / 100).strippedDecimalString(maxDecimalPlaces: 2),
+        kind: .decimal, range: range
+    )
+}
+
+private func doubles(_ values: [String], count: Int) -> [CGFloat]? {
+    guard values.count == count else { return nil }
+    var out: [CGFloat] = []
+    for v in values {
+        guard let d = Double(v.trimmingCharacters(in: .whitespaces)) else { return nil }
+        out.append(CGFloat(d))
+    }
+    return out
+}
+
+private func clamp(_ value: CGFloat, _ lower: CGFloat, _ upper: CGFloat) -> CGFloat {
+    Swift.min(Swift.max(value, lower), upper)
+}
+
+// swiftlint:enable identifier_name

--- a/Pika/Services/ColorDecomposition.swift
+++ b/Pika/Services/ColorDecomposition.swift
@@ -253,11 +253,22 @@ extension ColorFormat {
 
         case .lab:
             guard let triple = doubles(values, count: 3) else { return nil }
-            return NSColor.fromLab(l: triple[0], a: triple[1], b: triple[2])
+            // Only `l` has a range (0...100, matching `decompose`'s `labComponent`); `a`/`b`
+            // are intentionally unbounded, so nothing to clamp for them.
+            return NSColor.fromLab(l: clamp(triple[0], 0, 100), a: triple[1], b: triple[2])
 
         case .oklch:
             guard let triple = doubles(values, count: 3) else { return nil }
-            return NSColor.fromOklch(l: triple[0] / 100, c: triple[1], h: triple[2])
+            // Clamp all three to the same ranges `decompose` declares (l: 0...100, c: 0...1,
+            // h: 0...360) before computing — `fromOklch` derives RGB via `cos`/`sin` on `h` and
+            // has no clamping of its own, so an out-of-range value here silently computes a
+            // *different* colour than the one `EditableColorValue.clampValuesToRange` displays
+            // after snapping the typed text to those same bounds (e.g. h=400° would otherwise
+            // wrap to 40° instead of matching the clamped, displayed 360°/red).
+            let l = clamp(triple[0], 0, 100) / 100
+            let c = clamp(triple[1], 0, 1)
+            let h = clamp(triple[2], 0, 360)
+            return NSColor.fromOklch(l: l, c: c, h: h)
         }
     }
 }

--- a/Pika/Services/ColorPair.swift
+++ b/Pika/Services/ColorPair.swift
@@ -12,21 +12,9 @@ struct ColorPair: Codable, Identifiable, Equatable {
 
     // Reconstructs the color in Defaults[.colorSpace] — the same space toHexString()
     // reads from. This makes set() a no-op (colorSpace → colorSpace) so the stored
-    // hex round-trips exactly.
+    // hex round-trips exactly. Invalid/short hex falls back to black.
     private static func colorFromHex(_ hex: String) -> NSColor {
-        let fallback = NSColor.black.usingColorSpace(Defaults[.colorSpace]) ?? .black
-        let stripped = hex.replacingOccurrences(of: "#", with: "")
-        guard stripped.count == 6 else { return fallback }
-        let scanner = Scanner(string: stripped)
-        var rgb: UInt64 = 0
-        guard scanner.scanHexInt64(&rgb) else { return fallback }
-        let components: [CGFloat] = [
-            CGFloat((rgb >> 16) & 0xFF) / 255,
-            CGFloat((rgb >> 8) & 0xFF) / 255,
-            CGFloat(rgb & 0xFF) / 255,
-            1.0,
-        ]
-        return NSColor(colorSpace: Defaults[.colorSpace], components: components, count: 4)
+        NSColor.fromHex(hex) ?? NSColor.black.usingColorSpace(Defaults[.colorSpace]) ?? .black
     }
 
     static let maxHistory = 20

--- a/Pika/Services/ColorPair.swift
+++ b/Pika/Services/ColorPair.swift
@@ -12,9 +12,12 @@ struct ColorPair: Codable, Identifiable, Equatable {
 
     // Reconstructs the color in Defaults[.colorSpace] — the same space toHexString()
     // reads from. This makes set() a no-op (colorSpace → colorSpace) so the stored
-    // hex round-trips exactly. Invalid/short hex falls back to black.
+    // hex round-trips exactly. Stored hex is always 6 digits (from toHexString), so
+    // anything else is treated as corrupt and falls back to black.
     private static func colorFromHex(_ hex: String) -> NSColor {
-        NSColor.fromHex(hex) ?? NSColor.black.usingColorSpace(Defaults[.colorSpace]) ?? .black
+        let fallback = NSColor.black.usingColorSpace(Defaults[.colorSpace]) ?? .black
+        guard hex.replacingOccurrences(of: "#", with: "").count == 6 else { return fallback }
+        return NSColor.fromHex(hex) ?? fallback
     }
 
     static let maxHistory = 20

--- a/Pika/Services/Eyedropper.swift
+++ b/Pika/Services/Eyedropper.swift
@@ -1,3 +1,4 @@
+import Combine
 import Defaults
 import SwiftUI
 
@@ -70,6 +71,11 @@ class Eyedropper: ObservableObject {
     private var closestVector: ClosestVector?
 
     @objc @Published public var color: NSColor
+
+    /// Fires the instant this eyedropper's colour is set by a genuine screen pick (not a typed
+    /// edit) — lets the swatch flash briefly so a chained foreground-then-background pick reads
+    /// as two distinct events instead of one silent colour swap.
+    let pickFlash = PassthroughSubject<Void, Never>()
 
     private var overlayWindow = ColorPickOverlayWindow()
 
@@ -231,6 +237,7 @@ extension Eyedropper {
         }
 
         set(normalizedColor)
+        pickFlash.send()
 
         if chainContrasting,
            type == .foreground,

--- a/Pika/Services/LoadColors.swift
+++ b/Pika/Services/LoadColors.swift
@@ -296,7 +296,7 @@ final class ColorNamesManager: ObservableObject {
 
     /// A readable title for a list key the API didn't describe: `sanzoWadaI` -> `Sanzo Wada I`.
     private static func prettify(_ key: String) -> String {
-        if key == defaultColorListKey { return PikaText.textColorListDefault }
+        if key == defaultColorListKey { return "Default" }
         var result = ""
         for (index, character) in key.enumerated() {
             if index == 0 {

--- a/Pika/Services/LoadColors.swift
+++ b/Pika/Services/LoadColors.swift
@@ -296,7 +296,7 @@ final class ColorNamesManager: ObservableObject {
 
     /// A readable title for a list key the API didn't describe: `sanzoWadaI` -> `Sanzo Wada I`.
     private static func prettify(_ key: String) -> String {
-        if key == defaultColorListKey { return "Default" }
+        if key == defaultColorListKey { return PikaText.textColorListDefault }
         var result = ""
         for (index, character) in key.enumerated() {
             if index == 0 {

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -334,6 +334,7 @@ class WindowCoordinator: NSObject {
         // would show a blank floating window whenever the splash is dismissed in that mode.
         if !Defaults[.appMode].usesPopover, !pikaWindow.isVisible {
             pikaWindow.fadeIn(nil)
+            steerFirstResponderAwayFromFields()
         }
         applyShadowState()
         Defaults[.viewedSplash] = true
@@ -341,7 +342,21 @@ class WindowCoordinator: NSObject {
 
     func showMainWindow() {
         pikaWindow.makeKeyAndOrderFront(nil)
+        steerFirstResponderAwayFromFields()
         applyShadowState()
+    }
+
+    /// AppKit's own auto-focus (`_setUpFirstResponder`/`_selectFirstKeyView`) is meant to be
+    /// headed off once and for all by pointing `initialFirstResponder` at the content view (see
+    /// the comment at that assignment in `EditableColorValue.ScrubTextField.viewDidMoveToWindow`).
+    /// That holds for the window's very first appearance, but re-showing a window that was
+    /// previously ordered out (e.g. a pick landing while Pika was closed, which unconditionally
+    /// re-shows it via `showPika`) can still land on the first colour-value field instead —
+    /// resigning key status on hide appears to drop the current first responder, and re-deriving
+    /// one on the way back in doesn't always respect `initialFirstResponder`. Rather than chase
+    /// that AppKit-internal quirk, force it back every time the window is (re)shown.
+    private func steerFirstResponderAwayFromFields() {
+        pikaWindow.makeFirstResponder(pikaWindow.contentView)
     }
 
     func hideMainWindow() {
@@ -369,6 +384,7 @@ class WindowCoordinator: NSObject {
         } else {
             pikaWindow.fadeIn(sender: nil, duration: 0.2)
         }
+        steerFirstResponderAwayFromFields()
         applyShadowState()
         NSApp.activate(ignoringOtherApps: true)
     }

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -85,6 +85,7 @@ class WindowCoordinator: NSObject {
             self?.aboutWindow?.level = level
             self?.helpWindow?.level = level
             self?.preferencesWindow?.level = level
+            self?.splashWindow?.level = level
         }.tieToLifetime(of: self)
 
         // Keep the companion windows aligned to the main window as it resizes and moves.

--- a/Pika/Services/WindowCoordinator.swift
+++ b/Pika/Services/WindowCoordinator.swift
@@ -85,7 +85,6 @@ class WindowCoordinator: NSObject {
             self?.aboutWindow?.level = level
             self?.helpWindow?.level = level
             self?.preferencesWindow?.level = level
-            self?.splashWindow?.level = level
         }.tieToLifetime(of: self)
 
         // Keep the companion windows aligned to the main window as it resizes and moves.

--- a/Pika/Views/ColorPickers.swift
+++ b/Pika/Views/ColorPickers.swift
@@ -3,6 +3,13 @@ import SwiftUI
 struct ColorPickers: View {
     @EnvironmentObject var eyedroppers: Eyedroppers
 
+    /// Shared across both swatches rather than owned per-swatch: a click landing on either
+    /// swatch's pick target while a colour field is focused needs to dismiss whichever swatch
+    /// actually owns that field, not necessarily the one that was clicked (the window-wide
+    /// first-responder check in `EyedropperButton.PickTarget` can't tell them apart on its own).
+    /// Broadcasting the bump to both is harmless — only the swatch with an active session reacts.
+    @State private var dismissEditingTrigger: Int = 0
+
     var body: some View {
         let eyedropperArray: [Eyedropper] = [eyedroppers.foreground, eyedroppers.background]
 
@@ -10,7 +17,7 @@ struct ColorPickers: View {
             ForEach(Array(eyedropperArray.enumerated()), id: \.element.type) { _, eyedropper in
                 // No divider between the two swatches — the colours meet directly, and the
                 // horizontal section dividers do the framing.
-                EyedropperItem(eyedropper: eyedropper)
+                EyedropperItem(eyedropper: eyedropper, dismissEditingTrigger: $dismissEditingTrigger)
             }
         }
     }

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -1,0 +1,228 @@
+import Defaults
+import SwiftUI
+
+/// The "⚠ Invalid input" pill shown beside the type label while a focused field holds
+/// unparseable input. Coloured to the swatch's UI text colour so it reads on any background.
+struct InvalidInputPill: View {
+    let uiColor: NSColor
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "exclamationmark.triangle.fill")
+            Text(PikaText.textColorEditInvalid)
+        }
+        .font(.caption2)
+        .fontWeight(.semibold)
+        .foregroundStyle(Color(uiColor))
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(Capsule().fill(Color(uiColor).opacity(0.18)))
+    }
+}
+
+private struct EditableWidthKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
+}
+
+/// The editable colour readout. Fixed format scaffolding renders as dimmed, non-editable text;
+/// each numeric component is a focusable field. Valid edits preview live on `eyedropper` (which
+/// posts nothing, so history stays quiet); Enter or a valid blur commits — recording history once
+/// via `.colorPicked` — while Escape or an invalid blur reverts to the pre-edit colour.
+struct EditableColorValue: View {
+    @ObservedObject var eyedropper: Eyedropper
+    let format: ColorFormat
+    let style: CopyFormat
+    let colorSpace: NSColorSpace
+    /// Raised while the focused field holds unparseable input, so the parent can show the pill.
+    @Binding var isInvalid: Bool
+
+    private let baseSize: CGFloat = 18
+    private let minSize: CGFloat = 11
+
+    @State private var width: CGFloat = 0
+    /// Working component strings. Kept in sync with the colour when idle; owned by the user
+    /// while a field is focused.
+    @State private var values: [String] = []
+    @State private var isEditing = false
+    @State private var preEditColor: NSColor?
+    @FocusState private var focusedIndex: Int?
+
+    private var decomposed: DecomposedColor {
+        format.decompose(eyedropper.color, style: style, in: colorSpace)
+    }
+
+    private var uiColor: NSColor { eyedropper.color.getUIColor() }
+
+    // Deterministic font size from the full string width vs column width — same approach as the
+    // read-only AdaptiveValueText, but single-line (a wrapping row of fields reads poorly).
+    private func fontSize(for text: String) -> CGFloat {
+        guard width > 4 else { return baseSize }
+        let full = (text as NSString).size(withAttributes: [.font: NSFont.systemFont(ofSize: baseSize)]).width
+        guard full > 0 else { return baseSize }
+        let scale = min(1, width / full)
+        return max(minSize, baseSize * scale)
+    }
+
+    var body: some View {
+        let layout = decomposed
+        let size = fontSize(for: layout.joined())
+
+        HStack(alignment: .firstTextBaseline, spacing: 0) {
+            affix(layout.leading, size: size)
+            ForEach(Array(layout.components.enumerated()), id: \.offset) { index, component in
+                ColorComponentField(
+                    text: binding(for: index, layout: layout),
+                    component: component,
+                    index: index,
+                    uiColor: uiColor,
+                    fontSize: size,
+                    focusedIndex: $focusedIndex,
+                    onSubmit: commitEditing,
+                    onCancel: revertEditing
+                )
+                if index < layout.separators.count {
+                    affix(layout.separators[index], size: size)
+                }
+            }
+            affix(layout.trailing, size: size)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            GeometryReader { geo in
+                Color.clear.preference(key: EditableWidthKey.self, value: geo.size.width)
+            }
+        )
+        .onPreferenceChange(EditableWidthKey.self) { width = $0 }
+        .onAppear { syncValuesFromColor(layout) }
+        .onChange(of: focusedIndex) { newValue in handleFocusChange(to: newValue, layout: layout) }
+        .onChange(of: eyedropper.color) { _ in if !isEditing { syncValuesFromColor(decomposed) } }
+        .onChange(of: format) { _ in if !isEditing { syncValuesFromColor(decomposed) } }
+        .onChange(of: style) { _ in if !isEditing { syncValuesFromColor(decomposed) } }
+    }
+
+    private func affix(_ text: String, size: CGFloat) -> some View {
+        Text(text)
+            .font(.system(size: size, weight: .regular))
+            .foregroundStyle(Color(uiColor).opacity(0.5))
+    }
+
+    // MARK: - Values ↔ colour
+
+    private func syncValuesFromColor(_ layout: DecomposedColor) {
+        values = layout.values
+    }
+
+    private func binding(for index: Int, layout: DecomposedColor) -> Binding<String> {
+        Binding(
+            get: { index < values.count ? values[index] : layout.values[index] },
+            set: { newValue in
+                if values.count != layout.components.count { values = layout.values }
+                guard index < values.count else { return }
+                values[index] = newValue
+                previewIfValid(layout: layout)
+            }
+        )
+    }
+
+    // MARK: - Editing lifecycle
+
+    private func handleFocusChange(to newValue: Int?, layout: DecomposedColor) {
+        if newValue != nil {
+            // Entering (or moving between) fields — start a session on the first focus.
+            if !isEditing {
+                isEditing = true
+                preEditColor = eyedropper.color
+                values = layout.values
+            }
+        } else if isEditing {
+            // Focus left every field (blur / tab-out) — commit if valid, otherwise revert.
+            finishEditing()
+        }
+    }
+
+    /// Recompose the working values and preview them live; flag invalid input for the pill.
+    private func previewIfValid(layout: DecomposedColor) {
+        let allValid = zip(layout.components, values).allSatisfy { $0.isValid($1) }
+        isInvalid = !allValid
+        guard allValid, let color = format.recompose(values, style: style, in: colorSpace) else { return }
+        eyedropper.set(color)
+    }
+
+    private func commitEditing() {
+        // Called on Return: drop focus, which routes through finishEditing().
+        focusedIndex = nil
+    }
+
+    private func finishEditing() {
+        let layout = decomposed
+        let allValid = zip(layout.components, values).allSatisfy { $0.isValid($1) }
+        if allValid, let color = format.recompose(values, style: style, in: colorSpace) {
+            eyedropper.set(color)
+            NotificationCenter.default.post(name: .colorPicked, object: nil)
+        } else if let preEditColor {
+            eyedropper.set(preEditColor)
+        }
+        endSession()
+    }
+
+    private func revertEditing() {
+        if let preEditColor { eyedropper.set(preEditColor) }
+        focusedIndex = nil
+        endSession()
+    }
+
+    private func endSession() {
+        isEditing = false
+        isInvalid = false
+        preEditColor = nil
+        values = decomposed.values
+    }
+}
+
+/// A single focusable numeric/hex field styled to the swatch's UI colour, with the four design
+/// states: default (bare), hover (filled), focus (outlined), invalid (dashed outline).
+private struct ColorComponentField: View {
+    @Binding var text: String
+    let component: ColorComponent
+    let index: Int
+    let uiColor: NSColor
+    let fontSize: CGFloat
+    @FocusState.Binding var focusedIndex: Int?
+    let onSubmit: () -> Void
+    let onCancel: () -> Void
+
+    @State private var isHovering = false
+
+    private var isFocused: Bool { focusedIndex == index }
+    private var isInvalid: Bool { isFocused && !component.isValid(text) }
+
+    var body: some View {
+        TextField("", text: $text)
+            .textFieldStyle(.plain)
+            .font(.system(size: fontSize, weight: .regular))
+            .foregroundStyle(Color(uiColor))
+            .fixedSize()
+            .multilineTextAlignment(.center)
+            .focused($focusedIndex, equals: index)
+            .onSubmit(onSubmit)
+            .onExitCommand(perform: onCancel)
+            .padding(.horizontal, 3)
+            .padding(.vertical, 1)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color(uiColor).opacity(isHovering && !isFocused ? 0.18 : 0))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .strokeBorder(
+                        Color(uiColor).opacity(isFocused ? 0.9 : 0),
+                        style: StrokeStyle(lineWidth: 1, dash: isInvalid ? [2, 2] : [])
+                    )
+            )
+            .contentShape(Rectangle())
+            .onHover { isHovering = $0 }
+            .animation(.easeInOut(duration: 0.12), value: isHovering)
+            .animation(.easeInOut(duration: 0.12), value: isFocused)
+    }
+}

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -60,7 +60,13 @@ struct EditableColorValue: View {
     /// `onChange(of: eyedropper.color)` tell our own writes apart from an external pick landing
     /// mid-edit, so the latter can abort the session instead of being silently overwritten.
     @State private var lastPreviewedColor: NSColor?
-    @FocusState private var focusedIndex: Int?
+    /// Plain `@State`, not `@FocusState`: nothing here is bound via `.focused()` to an actual
+    /// SwiftUI-focusable view (the field is a raw AppKit `NSTextField`, focus is driven by hand
+    /// through `ColorComponentField`'s `onFocusChange`). `@FocusState` expects to reconcile
+    /// against the real focus environment and would get silently reset to `nil` by unrelated
+    /// window/focus churn — e.g. a sibling's hover state changing — dropping the outline and
+    /// ending the edit the moment the mouse left the field, even mid-session.
+    @State private var focusedIndex: Int?
 
     private var decomposed: DecomposedColor {
         format.decompose(eyedropper.color, style: style, in: colorSpace)
@@ -278,7 +284,7 @@ private struct ColorComponentField: View {
     let index: Int
     let uiColor: NSColor
     let fontSize: CGFloat
-    @FocusState.Binding var focusedIndex: Int?
+    @Binding var focusedIndex: Int?
     let onSubmit: () -> Void
     let onCancel: () -> Void
     /// Fired when a drag-to-scrub gesture starts/ends, so the parent can wrap it in the same
@@ -360,7 +366,9 @@ private struct ColorComponentField: View {
             onDragBegin()
         }
         guard let origin = scrollOrigin else { return }
-        scrollAccumulated += deltaY
+        // Inverted: scrolling up (negative deltaY) increases the value, matching the direction
+        // users expect when nudging a number via a scroll gesture.
+        scrollAccumulated -= deltaY
         let fine = NSEvent.modifierFlags.contains(.option)
         var newValue = origin + Double(scrollAccumulated) * (fine ? 0.1 : 1.0)
         if let range = component.range {
@@ -590,7 +598,10 @@ private struct ScrubbableColorField: NSViewRepresentable {
 /// A resolved click focuses normally; `becomeFirstResponder` then deterministically collapses
 /// AppKit's default select-all in the same call stack, rather than reacting to it after the fact.
 private final class ScrubTextField: NSTextField {
-    var isDraggable = false
+    var isDraggable = false {
+        didSet { window?.invalidateCursorRects(for: self) }
+    }
+
     var range: ClosedRange<Double>?
     var kind: ComponentKind = .integer
     var onDragBegin: (() -> Void)?
@@ -610,11 +621,37 @@ private final class ScrubTextField: NSTextField {
 
     override func becomeFirstResponder() -> Bool {
         let result = super.becomeFirstResponder()
-        if result, let editor = currentEditor() {
-            let length = (editor.string as NSString).length
-            editor.selectedRange = NSRange(location: length, length: 0)
+        if result {
+            if let editor = currentEditor() {
+                let length = (editor.string as NSString).length
+                editor.selectedRange = NSRange(location: length, length: 0)
+            }
+            window?.invalidateCursorRects(for: self)
         }
         return result
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let result = super.resignFirstResponder()
+        if result { window?.invalidateCursorRects(for: self) }
+        return result
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        window?.invalidateCursorRects(for: self)
+    }
+
+    // NSTextField's own `resetCursorRects()` covers `bounds` with an I-beam cursor rect, which
+    // wins over the SwiftUI `.onHover`-driven `NSCursor.set()` the moment the mouse enters this
+    // AppKit view — that's why the resize cursor from the parent's hover handling was reverting
+    // to `|` over the text itself. Claim the rect ourselves while draggable and not being edited.
+    override func resetCursorRects() {
+        guard isDraggable, currentEditor() == nil else {
+            super.resetCursorRects()
+            return
+        }
+        addCursorRect(bounds, cursor: .resizeLeftRight)
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -237,11 +237,19 @@ struct EditableColorValue: View {
             eyedropper.set(color)
             lastPreviewedColor = eyedropper.color
             NotificationCenter.default.post(name: .colorPicked, object: nil)
+            // Don't resync `values` from the just-committed colour: some formats are lossy at
+            // their extremes (e.g. HSB hue/saturation are undefined at brightness 0), so
+            // decomposing straight back can silently discard what was just typed — e.g. typing
+            // hsb(0, 50%, 0%) round-trips through black and reports back 0% saturation. `values`
+            // already holds exactly what was committed, which is the more faithful thing to show.
+            endSession(resync: false)
         } else if let preEditColor {
             eyedropper.set(preEditColor)
             lastPreviewedColor = eyedropper.color
+            endSession(resync: true)
+        } else {
+            endSession(resync: true)
         }
-        endSession()
     }
 
     private func revertEditing() {
@@ -250,22 +258,22 @@ struct EditableColorValue: View {
             eyedropper.set(preEditColor)
         }
         focusedIndex = nil
-        endSession()
+        endSession(resync: true)
     }
 
     /// An external eyedropper pick landed while a field was focused — abort the edit so the
     /// pick wins, rather than letting a later blur silently overwrite it with typed values.
     private func abortEditingForExternalPick() {
         focusedIndex = nil
-        endSession()
+        endSession(resync: true)
     }
 
-    private func endSession() {
+    private func endSession(resync: Bool) {
         isEditing = false
         isInvalid = false
         preEditColor = nil
         lastPreviewedColor = nil
-        syncValuesFromColor(decomposed)
+        if resync { syncValuesFromColor(decomposed) }
     }
 }
 
@@ -297,6 +305,9 @@ private struct ColorComponentField: View {
     /// scroll start. `scrollAccumulated` tracks total vertical scroll since then.
     @State private var scrollOrigin: Double?
     @State private var scrollAccumulated: CGFloat = 0
+    /// Bumped on every focus event (begin or end) this field reports; see the deferred-blur
+    /// comment at its use in `onFocusChange` below.
+    @State private var focusVersion = 0
 
     private var isFocused: Bool { focusedIndex == index }
     private var isInvalid: Bool { isFocused && !component.isValid(text) }
@@ -312,11 +323,35 @@ private struct ColorComponentField: View {
             range: component.range,
             kind: component.kind,
             isFocused: isFocused,
-            onFocusChange: { focused in focusedIndex = focused ? index : (focusedIndex == index ? nil : focusedIndex) },
+            onFocusChange: { focused in
+                // AppKit doesn't always report a clean single "begin": both a direct
+                // field-to-field focus move (old field resigns before the new one becomes first
+                // responder) *and*, it turns out, a field gaining focus from nothing at all
+                // (its own internal resign/become choreography when a click lands on it) can
+                // report a spurious "end" immediately before — or, in the from-nothing case,
+                // interleaved with — the real "begin". Reacting to an "end" synchronously would
+                // tear the whole edit session down for a frame (dropping the outline, ending
+                // editing) only to immediately restart it — or, worse, incorrectly cancel a
+                // "begin" for the very same field that arrives a moment later. Defer the "end"
+                // one runloop turn and only apply it if nothing else has touched focus since:
+                // `focusVersion` is bumped on every focus event, so a later event (for this
+                // field or another) invalidates a stale deferred "end".
+                focusVersion += 1
+                if focused {
+                    focusedIndex = index
+                } else {
+                    let expectedVersion = focusVersion
+                    DispatchQueue.main.async {
+                        guard focusVersion == expectedVersion, focusedIndex == index else { return }
+                        focusedIndex = nil
+                    }
+                }
+            },
             onSubmit: onSubmit,
             onCancel: onCancel,
             onDragBegin: onDragBegin,
-            onDragEnd: onDragEnd
+            onDragEnd: onDragEnd,
+            onStep: isDraggable ? stepValue : nil
         )
         .fixedSize()
         .padding(.horizontal, 1)
@@ -354,6 +389,19 @@ private struct ColorComponentField: View {
             }
             .allowsHitTesting(false)
         )
+    }
+
+    /// Up/Down arrow keys nudge the focused field by ±1 (±0.1 with Option), same as a single
+    /// step of click-drag or scroll scrubbing — applied straight to the live-preview binding
+    /// since the field is already mid-edit (it has to be focused to receive the key at all).
+    private func stepValue(_ direction: CGFloat) {
+        let current = Double(text.trimmingCharacters(in: .whitespaces)) ?? 0
+        let fine = NSEvent.modifierFlags.contains(.option)
+        var newValue = current + Double(direction) * (fine ? 0.1 : 1.0)
+        if let range = component.range {
+            newValue = min(max(newValue, range.lowerBound), range.upperBound)
+        }
+        text = Self.formattedDragValue(newValue, kind: component.kind)
     }
 
     /// Two-finger trackpad scroll nudges the value the same way click-drag does: accumulated
@@ -500,9 +548,11 @@ private struct ScrubbableColorField: NSViewRepresentable {
     /// same live-preview/commit session used for typed edits.
     let onDragBegin: () -> Void
     let onDragEnd: () -> Void
+    /// Fired with +1/-1 for Up/Down arrow keys, `nil` for non-draggable (hex) fields.
+    let onStep: ((CGFloat) -> Void)?
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text, onSubmit: onSubmit, onCancel: onCancel, onFocusChange: onFocusChange)
+        Coordinator(text: $text, onSubmit: onSubmit, onCancel: onCancel, onStep: onStep)
     }
 
     func makeNSView(context: Context) -> ScrubTextField {
@@ -521,6 +571,15 @@ private struct ScrubbableColorField: NSViewRepresentable {
 
     func updateNSView(_ nsView: ScrubTextField, context: Context) {
         context.coordinator.text = $text
+        // Driven off `becomeFirstResponder`/`resignFirstResponder` directly rather than the
+        // `NSTextFieldDelegate` controlTextDidBeginEditing/EndEditing notifications: a click that
+        // lands on a not-yet-focused field goes through AppKit's own private pre-focus path
+        // (`NSWindow._handleMouseDownEvent:` → `NSTextFieldCell _selectOrEdit:…`) *before* this
+        // view's `mouseDown` override ever runs, and that path never posts the notifications the
+        // delegate relies on — so `focusedIndex` silently never got set, and the focus outline
+        // never appeared. The responder overrides fire reliably however focus changes.
+        nsView.onFocusChange = onFocusChange
+        context.coordinator.onStep = onStep
         if nsView.font?.pointSize != fontSize {
             nsView.font = NSFont.systemFont(ofSize: fontSize, weight: .regular)
             nsView.invalidateIntrinsicContentSize()
@@ -560,22 +619,38 @@ private struct ScrubbableColorField: NSViewRepresentable {
         var text: Binding<String>
         let onSubmit: () -> Void
         let onCancel: () -> Void
-        let onFocusChange: (Bool) -> Void
+        var onStep: ((CGFloat) -> Void)?
 
-        init(text: Binding<String>, onSubmit: @escaping () -> Void, onCancel: @escaping () -> Void, onFocusChange: @escaping (Bool) -> Void) {
+        init(
+            text: Binding<String>, onSubmit: @escaping () -> Void, onCancel: @escaping () -> Void,
+            onStep: ((CGFloat) -> Void)?
+        ) {
             self.text = text
             self.onSubmit = onSubmit
             self.onCancel = onCancel
-            self.onFocusChange = onFocusChange
+            self.onStep = onStep
         }
 
         func controlTextDidChange(_ obj: Notification) {
-            guard let field = obj.object as? NSTextField else { return }
+            guard let field = obj.object as? ScrubTextField else { return }
+            // Clearing a ranged field (select-all + delete, or backspacing the last digit)
+            // leaves it both empty and invalid — effectively a dead end, since an empty
+            // `.fixedSize()` field also collapses to no width, hiding the invalid-state dashes
+            // that would otherwise show. Snap it to the component's lowest value instead, and
+            // select it, so the field stays visible, valid, and ready to be typed straight over
+            // — mirroring what a fresh click-to-select does. Hex has no natural minimum
+            // (`range` is nil), so it keeps the plain empty/invalid state.
+            if field.stringValue.isEmpty, let range = field.range {
+                let lowest = ColorComponentField.formattedDragValue(range.lowerBound, kind: field.kind)
+                field.stringValue = lowest
+                text.wrappedValue = lowest
+                if let editor = field.currentEditor() {
+                    editor.selectedRange = NSRange(location: 0, length: (lowest as NSString).length)
+                }
+                return
+            }
             text.wrappedValue = field.stringValue
         }
-
-        func controlTextDidBeginEditing(_: Notification) { onFocusChange(true) }
-        func controlTextDidEndEditing(_: Notification) { onFocusChange(false) }
 
         func control(_: NSControl, textView _: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
@@ -584,6 +659,14 @@ private struct ScrubbableColorField: NSViewRepresentable {
             }
             if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
                 onCancel()
+                return true
+            }
+            if commandSelector == #selector(NSResponder.moveUp(_:)), let onStep {
+                onStep(1)
+                return true
+            }
+            if commandSelector == #selector(NSResponder.moveDown(_:)), let onStep {
+                onStep(-1)
                 return true
             }
             return false
@@ -595,8 +678,9 @@ private struct ScrubbableColorField: NSViewRepresentable {
 /// *before* anything can focus — no second view or event monitor racing the field's native click
 /// handling. A resolved drag never touches first-responder status at all, so the field just
 /// displays a changing string like a label while scrubbing (no editor, no selection, no caret).
-/// A resolved click focuses normally; `becomeFirstResponder` then deterministically collapses
-/// AppKit's default select-all in the same call stack, rather than reacting to it after the fact.
+/// A resolved click focuses normally; `becomeFirstResponder` then deterministically selects the
+/// whole value in the same call stack (matching the click-to-select-all behaviour of a spreadsheet
+/// cell), rather than reacting to AppKit's own click-positions-the-caret behaviour after the fact.
 private final class ScrubTextField: NSTextField {
     var isDraggable = false {
         didSet { window?.invalidateCursorRects(for: self) }
@@ -607,6 +691,10 @@ private final class ScrubTextField: NSTextField {
     var onDragBegin: (() -> Void)?
     var onDragChanged: ((Double) -> Void)?
     var onDragEnd: (() -> Void)?
+    /// Reports true/false as this field becomes/resigns first responder. Driven from these
+    /// overrides rather than `NSTextFieldDelegate`'s controlTextDidBeginEditing/EndEditing —
+    /// see the note at the `onFocusChange` assignment in `ScrubbableColorField.updateNSView`.
+    var onFocusChange: ((Bool) -> Void)?
 
     private var dragOrigin: Double?
 
@@ -620,26 +708,46 @@ private final class ScrubTextField: NSTextField {
     }
 
     override func becomeFirstResponder() -> Bool {
+        // AppKit's own `_setUpFirstResponder`/`_selectFirstKeyView` auto-focuses the first key
+        // view in the window while it's still being ordered onto screen — before it's key —
+        // which would open an edit session (and select-all) on the hue field before the user
+        // has clicked anything. Reject that call outright; genuine focus (click, Tab, or our
+        // own `updateNSView` reconciliation) only ever happens once the window is already key.
+        guard window?.isKeyWindow == true else { return false }
         let result = super.becomeFirstResponder()
         if result {
             if let editor = currentEditor() {
                 let length = (editor.string as NSString).length
-                editor.selectedRange = NSRange(location: length, length: 0)
+                editor.selectedRange = NSRange(location: 0, length: length)
             }
             window?.invalidateCursorRects(for: self)
+            onFocusChange?(true)
         }
         return result
     }
 
     override func resignFirstResponder() -> Bool {
         let result = super.resignFirstResponder()
-        if result { window?.invalidateCursorRects(for: self) }
+        if result {
+            window?.invalidateCursorRects(for: self)
+            onFocusChange?(false)
+        }
         return result
     }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         window?.invalidateCursorRects(for: self)
+        // Without this, AppKit's own `_setUpFirstResponder`/`_selectFirstKeyView` auto-focuses
+        // the first key view in the window (i.e. this field, if it's first in the hierarchy) the
+        // moment the window becomes key — opening an edit session on the hue field before the
+        // user has clicked anything. `becomeFirstResponder` reports that focus like any other
+        // (correctly, so genuine focus changes stay in sync), so SwiftUI accepts it and shows the
+        // outline. Steer AppKit's auto-pick to the content view instead, which never becomes an
+        // editing session. Harmless to set repeatedly (once per field that attaches).
+        if let window, window.initialFirstResponder !== window.contentView {
+            window.initialFirstResponder = window.contentView
+        }
     }
 
     // NSTextField's own `resetCursorRects()` covers `bounds` with an I-beam cursor rect, which
@@ -693,8 +801,19 @@ private final class ScrubTextField: NSTextField {
                     finishDrag()
                 } else {
                     // A genuine click: focus normally, exactly like a plain click on any
-                    // ordinary text field would.
-                    window?.makeFirstResponder(self)
+                    // ordinary text field would. AppKit's own event routing
+                    // (`_handleMouseDownEvent:` → `NSTextFieldCell _selectOrEdit:`) already
+                    // focuses the field before this override even runs — calling
+                    // `makeFirstResponder` again here forces a redundant resign/become pair
+                    // that corrupts the field editor's begin-editing bookkeeping, so
+                    // `controlTextDidBeginEditing` silently never fires and the field never
+                    // reports itself focused to SwiftUI (no outline, no edit session). Once
+                    // focused, first responder is the *field editor* (an NSTextView), not this
+                    // control itself, so check against `currentEditor()` rather than `self`.
+                    let editorIsActive = currentEditor() != nil && window?.firstResponder === currentEditor()
+                    if !editorIsActive {
+                        window?.makeFirstResponder(self)
+                    }
                 }
                 return
             default:
@@ -707,6 +826,17 @@ private final class ScrubTextField: NSTextField {
     private func beginDrag() {
         dragOrigin = Double(stringValue.trimmingCharacters(in: .whitespaces)) ?? 0
         NSCursor.resizeLeftRight.set()
+        // AppKit's own event routing (`_handleMouseDownEvent:` → `NSTextFieldCell
+        // _selectOrEdit:`) already focused and select-all'd this field as part of routing the
+        // mouseDown that's turning out to be this drag — before this override's loop could
+        // tell click from drag apart. Collapse that selection now that we know it's a drag, so
+        // releasing the mouse doesn't leave the dragged-to value shown text-selected. Just the
+        // selection, not the focus itself — resigning first responder here would race the
+        // deferred focus-loss handling in `EditableColorValue` and could end the drag's edit
+        // session (commit/revert) while the user is still mid-drag.
+        if let editor = currentEditor() {
+            editor.selectedRange = NSRange(location: (editor.string as NSString).length, length: 0)
+        }
         onDragBegin?()
     }
 

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -75,6 +75,14 @@ struct EditableColorValue: View {
     /// window/focus churn — e.g. a sibling's hover state changing — dropping the outline and
     /// ending the edit the moment the mouse left the field, even mid-session.
     @State private var focusedIndex: Int?
+    /// Which field the currently-open session (if any) belongs to — always non-nil whenever
+    /// `isEditing` is true, kept in sync with `focusedIndex` whenever focus moves but, unlike
+    /// `focusedIndex`, also set for a fresh unfocused scrub session (drag/scroll deliberately
+    /// never focuses the real field — see `beginDragSession`'s comment). Exists so a scrub
+    /// session's end — `onDragEnd`, which for scroll-to-scrub can arrive late via trailing
+    /// trackpad momentum — can tell "this is still my session" apart from "a different field
+    /// has since taken over, or this session already ended and a new one started elsewhere."
+    @State private var sessionOwner: Int?
 
     private var decomposed: DecomposedColor {
         format.decompose(eyedropper.color, style: style, in: colorSpace)
@@ -109,7 +117,7 @@ struct EditableColorValue: View {
                     onSubmit: commitEditing,
                     onCancel: revertEditing,
                     onDragBegin: { beginDragSession(index: index, layout: layout) },
-                    onDragEnd: finishEditing
+                    onDragEnd: { finishDragOrScrollSession(index: index) }
                 )
                 if index < layout.separators.count {
                     affix(layout.separators[index], size: size)
@@ -202,6 +210,7 @@ struct EditableColorValue: View {
     /// and fights the scrub with click-to-edit/select-all behaviour. An unfocused `TextField`
     /// with a changing `text` binding just renders like a label — no editor involved.
     private func beginDragSession(index: Int, layout: DecomposedColor) {
+        sessionOwner = index
         if isEditing {
             focusedIndex = index
             return
@@ -210,8 +219,10 @@ struct EditableColorValue: View {
     }
 
     private func handleFocusChange(to newValue: Int?, layout: DecomposedColor) {
-        if newValue != nil {
-            // Entering (or moving between) fields — start a session on the first focus.
+        if let newValue {
+            // Entering (or moving between) fields — start a session on the first focus, or
+            // (per the comment on `sessionOwner`) take over an existing unfocused scrub session.
+            sessionOwner = newValue
             if !isEditing {
                 startSession(layout: layout)
             }
@@ -219,6 +230,17 @@ struct EditableColorValue: View {
             // Focus left every field (blur / tab-out) — commit if valid, otherwise revert.
             finishEditing()
         }
+    }
+
+    /// `onDragEnd` for click-drag scrub is driven by a synchronous, blocking event-tracking loop
+    /// (`ScrubTextField.mouseDown`), so it can never fire late — nothing else can run until it
+    /// returns. Scroll-to-scrub's end can, though: trailing trackpad momentum can deliver
+    /// `onScrollEnd` well after a different field has taken over the session (a plain click
+    /// focusing it, or a fresh drag/scroll on it), or after this session already ended and a new
+    /// one started elsewhere. Only finish if `index` is still the session's current owner.
+    private func finishDragOrScrollSession(index: Int) {
+        guard isEditing, sessionOwner == index else { return }
+        finishEditing()
     }
 
     /// Snapshot the colour and working values at the start of an edit or drag session, so
@@ -286,8 +308,17 @@ struct EditableColorValue: View {
         isEditing = false
         isInvalid = false
         preEditColor = nil
-        lastPreviewedColor = nil
-        if resync { syncValuesFromColor(decomposed) }
+        sessionOwner = nil
+        // Only clear the own-write marker when we're about to resync anyway. A `resync: false`
+        // commit (see `finishEditing`'s success path) deliberately keeps `values` as typed rather
+        // than the freshly (and possibly lossily) decomposed colour — clearing this unconditionally
+        // made the very next `onChange(of: eyedropper.color)` pass see `newValue != nil` and
+        // resync anyway, undoing that on the next render and silently discarding what was just
+        // committed (e.g. hue snapping back to 0 once brightness/saturation round-trip through it).
+        if resync {
+            lastPreviewedColor = nil
+            syncValuesFromColor(decomposed)
+        }
     }
 }
 

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -37,6 +37,14 @@ struct EditableColorValue: View {
     let colorSpace: NSColorSpace
     /// Raised while the focused field holds unparseable input, so the parent can show the pill.
     @Binding var isInvalid: Bool
+    /// Bumped by the parent to end any active edit session (e.g. a click landing elsewhere in the
+    /// swatch that's meant to dismiss a focused field rather than act on it). Driving this
+    /// straight through `focusedIndex` rather than via AppKit's responder chain (e.g.
+    /// `window.endEditing(for:)`) matters: that resigns the field editor, but `ScrubTextField`'s
+    /// own `resignFirstResponder` override — the thing that actually reports the blur back up
+    /// via `onFocusChange` — doesn't reliably fire for it, leaving this view's local state (and
+    /// its focus outline) stuck showing "focused" even once AppKit itself has moved on.
+    var dismissEditingTrigger: Int = 0
 
     private let baseSize: CGFloat = 18
     private let minSize: CGFloat = 11
@@ -123,12 +131,18 @@ struct EditableColorValue: View {
                 // A change we didn't push ourselves is an external pick landing mid-edit —
                 // abort the session so the external colour wins, matching pre-edit behaviour.
                 if newValue != lastPreviewedColor { abortEditingForExternalPick() }
-            } else {
+            } else if newValue != lastPreviewedColor {
+                // Only resync from a colour we didn't just set ourselves. Without this check,
+                // this handler fires right after our own commit lands (isEditing has already
+                // flipped false by then) and undoes finishEditing's deliberate `resync: false` —
+                // e.g. snapping a just-typed hue back to 0 once brightness/saturation round-trips
+                // it through a colour where hue is undefined.
                 syncValuesFromColor(decomposed)
             }
         }
         .onChange(of: format) { _ in handleFormatOrStyleChange() }
         .onChange(of: style) { _ in handleFormatOrStyleChange() }
+        .onChange(of: dismissEditingTrigger) { _ in focusedIndex = nil }
     }
 
     private func affix(_ text: String, size: CGFloat) -> some View {

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -40,10 +40,19 @@ struct EditableColorValue: View {
     private let baseSize: CGFloat = 18
     private let minSize: CGFloat = 11
 
+    /// Identifies which (format, style) a cached `values` array was decomposed for, so a
+    /// format/style switch is detected even when the component count doesn't change (every
+    /// non-hex format always has exactly 3 components).
+    private struct FormatStyleKey: Equatable {
+        let format: ColorFormat
+        let style: CopyFormat
+    }
+
     @State private var width: CGFloat = 0
     /// Working component strings. Kept in sync with the colour when idle; owned by the user
     /// while a field is focused.
     @State private var values: [String] = []
+    @State private var valuesKey: FormatStyleKey?
     @State private var isEditing = false
     @State private var preEditColor: NSColor?
     /// The colour we last pushed to `eyedropper` ourselves (live preview or commit). Lets
@@ -83,7 +92,9 @@ struct EditableColorValue: View {
                     fontSize: size,
                     focusedIndex: $focusedIndex,
                     onSubmit: commitEditing,
-                    onCancel: revertEditing
+                    onCancel: revertEditing,
+                    onDragBegin: { beginDragSession(layout: layout) },
+                    onDragEnd: finishEditing
                 )
                 if index < layout.separators.count {
                     affix(layout.separators[index], size: size)
@@ -109,27 +120,37 @@ struct EditableColorValue: View {
                 syncValuesFromColor(decomposed)
             }
         }
-        .onChange(of: format) { _ in if !isEditing { syncValuesFromColor(decomposed) } }
-        .onChange(of: style) { _ in if !isEditing { syncValuesFromColor(decomposed) } }
+        .onChange(of: format) { _ in handleFormatOrStyleChange() }
+        .onChange(of: style) { _ in handleFormatOrStyleChange() }
     }
 
     private func affix(_ text: String, size: CGFloat) -> some View {
         Text(text)
             .font(.system(size: size, weight: .regular))
             .foregroundStyle(Color(uiColor).opacity(0.5))
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
     }
 
     // MARK: - Values ↔ colour
 
     private func syncValuesFromColor(_ layout: DecomposedColor) {
         values = layout.values
+        valuesKey = FormatStyleKey(format: format, style: style)
     }
 
     private func binding(for index: Int, layout: DecomposedColor) -> Binding<String> {
-        Binding(
-            get: { index < values.count ? values[index] : layout.values[index] },
+        let currentKey = FormatStyleKey(format: format, style: style)
+        return Binding(
+            get: {
+                guard valuesKey == currentKey, index < values.count else { return layout.values[index] }
+                return values[index]
+            },
             set: { newValue in
-                if values.count != layout.components.count { values = layout.values }
+                if valuesKey != currentKey || values.count != layout.components.count {
+                    values = layout.values
+                    valuesKey = currentKey
+                }
                 guard index < values.count else { return }
                 values[index] = newValue
                 previewIfValid(layout: layout)
@@ -139,6 +160,25 @@ struct EditableColorValue: View {
 
     // MARK: - Editing lifecycle
 
+    /// A format or copy-style switch changes how the same colour is *displayed*, not the colour
+    /// itself. Mid-edit, the typed values are in the old format's units and can't be reinterpreted
+    /// safely, so abort the session rather than risk a bogus commit; otherwise just resync.
+    private func handleFormatOrStyleChange() {
+        if isEditing {
+            abortEditingForExternalPick()
+        } else {
+            syncValuesFromColor(decomposed)
+        }
+    }
+
+    private func beginDragSession(layout: DecomposedColor) {
+        guard !isEditing else { return }
+        isEditing = true
+        preEditColor = eyedropper.color
+        values = layout.values
+        valuesKey = FormatStyleKey(format: format, style: style)
+    }
+
     private func handleFocusChange(to newValue: Int?, layout: DecomposedColor) {
         if newValue != nil {
             // Entering (or moving between) fields — start a session on the first focus.
@@ -146,6 +186,7 @@ struct EditableColorValue: View {
                 isEditing = true
                 preEditColor = eyedropper.color
                 values = layout.values
+                valuesKey = FormatStyleKey(format: format, style: style)
             }
         } else if isEditing {
             // Focus left every field (blur / tab-out) — commit if valid, otherwise revert.
@@ -202,7 +243,7 @@ struct EditableColorValue: View {
         isInvalid = false
         preEditColor = nil
         lastPreviewedColor = nil
-        values = decomposed.values
+        syncValuesFromColor(decomposed)
     }
 }
 
@@ -217,11 +258,19 @@ private struct ColorComponentField: View {
     @FocusState.Binding var focusedIndex: Int?
     let onSubmit: () -> Void
     let onCancel: () -> Void
+    /// Fired when a drag-to-scrub gesture starts/ends, so the parent can wrap it in the same
+    /// live-preview/commit session used for typed edits (one history entry per drag, not per pixel).
+    let onDragBegin: () -> Void
+    let onDragEnd: () -> Void
 
     @State private var isHovering = false
+    /// Non-nil while a drag-to-scrub gesture owns this field; holds the value at drag start.
+    @State private var dragOrigin: Double?
 
     private var isFocused: Bool { focusedIndex == index }
     private var isInvalid: Bool { isFocused && !component.isValid(text) }
+    /// Hex is a single opaque string with no natural min/max to scrub between.
+    private var isDraggable: Bool { component.kind != .hex }
 
     var body: some View {
         TextField("", text: $text)
@@ -231,6 +280,9 @@ private struct ColorComponentField: View {
             .fixedSize()
             .multilineTextAlignment(.center)
             .focused($focusedIndex, equals: index)
+            // We already draw a custom focus outline below; the system's own focus ring is wider
+            // than that outline and made focused fields look larger than their neighbours.
+            .focusEffectDisabled()
             .onSubmit(onSubmit)
             .onExitCommand(perform: onCancel)
             .padding(.horizontal, 3)
@@ -247,8 +299,56 @@ private struct ColorComponentField: View {
                     )
             )
             .contentShape(Rectangle())
-            .onHover { isHovering = $0 }
+            .onHover { hovering in
+                isHovering = hovering
+                guard isDraggable, !isFocused else { return }
+                if hovering { NSCursor.resizeLeftRight.set() } else { NSCursor.arrow.set() }
+            }
             .animation(.easeInOut(duration: 0.12), value: isHovering)
             .animation(.easeInOut(duration: 0.12), value: isFocused)
+            // Only competes with the TextField's own click/drag-to-select while unfocused, so
+            // typing and text selection inside an already-focused field are unaffected.
+            .gesture(
+                DragGesture(minimumDistance: 2)
+                    .onChanged(handleDragChanged)
+                    .onEnded(handleDragEnded),
+                including: isDraggable && !isFocused ? .all : .subviews
+            )
+    }
+
+    /// Click-and-drag left/right nudges the value: 1 unit per pixel, or 0.1 per pixel while
+    /// holding Option for fine adjustment. Clamped to the component's range when it has one.
+    private func handleDragChanged(_ value: DragGesture.Value) {
+        guard isDraggable else { return }
+        if dragOrigin == nil {
+            dragOrigin = Double(text.trimmingCharacters(in: .whitespaces)) ?? 0
+            NSCursor.resizeLeftRight.set()
+            onDragBegin()
+        }
+        guard let origin = dragOrigin else { return }
+        let fine = NSEvent.modifierFlags.contains(.option)
+        var newValue = origin + Double(value.translation.width) * (fine ? 0.1 : 1.0)
+        if let range = component.range {
+            newValue = min(max(newValue, range.lowerBound), range.upperBound)
+        }
+        text = Self.formattedDragValue(newValue, kind: component.kind)
+    }
+
+    private func handleDragEnded(_: DragGesture.Value) {
+        guard dragOrigin != nil else { return }
+        dragOrigin = nil
+        NSCursor.arrow.set()
+        onDragEnd()
+    }
+
+    private static func formattedDragValue(_ value: Double, kind: ComponentKind) -> String {
+        switch kind {
+        case .hex:
+            return ""
+        case .integer:
+            return String(Int(value.rounded()))
+        case .decimal:
+            return CGFloat(value).strippedDecimalString(maxDecimalPlaces: 4)
+        }
     }
 }

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -93,7 +93,7 @@ struct EditableColorValue: View {
                     focusedIndex: $focusedIndex,
                     onSubmit: commitEditing,
                     onCancel: revertEditing,
-                    onDragBegin: { beginDragSession(layout: layout) },
+                    onDragBegin: { beginDragSession(index: index, layout: layout) },
                     onDragEnd: finishEditing
                 )
                 if index < layout.separators.count {
@@ -171,12 +171,20 @@ struct EditableColorValue: View {
         }
     }
 
-    private func beginDragSession(layout: DecomposedColor) {
-        guard !isEditing else { return }
+    /// Starting a drag on a field that isn't the one currently owning the edit session (if any)
+    /// joins that session by moving focus to it, the same way clicking a new field mid-edit does
+    /// in `handleFocusChange` — rather than letting a second, session-less drag mutate the shared
+    /// `values` array and then tear down the first field's session on release.
+    private func beginDragSession(index: Int, layout: DecomposedColor) {
+        if isEditing {
+            focusedIndex = index
+            return
+        }
         isEditing = true
         preEditColor = eyedropper.color
         values = layout.values
         valuesKey = FormatStyleKey(format: format, style: style)
+        focusedIndex = index
     }
 
     private func handleFocusChange(to newValue: Int?, layout: DecomposedColor) {

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -241,6 +241,20 @@ struct EditableColorValue: View {
     private func finishDragOrScrollSession(index: Int) {
         guard isEditing, sessionOwner == index else { return }
         finishEditing()
+        // AppKit implicitly focuses (and select-alls) a field as part of routing the mouseDown
+        // that turns out to be a click-drag (see `ScrubTextField.beginDrag`'s comment) —
+        // regardless of whether the drag started fresh or on an already-focused field. A scrub
+        // must never leave the field looking like an active text edit once it's done (the
+        // "renders like a label" intent documented on `beginDragSession` above); `finishEditing`/
+        // `endSession` only manage `isEditing`, not `focusedIndex`. Clearing it here — rather
+        // than resigning first responder directly from AppKit — routes through the same
+        // `updateNSView` reconciliation (`isFocused`/`editorIsActive`) that already reliably
+        // drives real focus changes elsewhere, instead of depending on `resignFirstResponder`
+        // firing for a resign that didn't originate from `self` becoming first responder, which
+        // proved unreliable (see `PickTarget`'s `dismissEditingTrigger`).
+        if focusedIndex == index {
+            focusedIndex = nil
+        }
     }
 
     /// Snapshot the colour and working values at the start of an edit or drag session, so
@@ -261,6 +275,23 @@ struct EditableColorValue: View {
         lastPreviewedColor = eyedropper.color
     }
 
+    /// Snaps any component whose typed value fell outside its range to the nearest bound,
+    /// in place, using the same string formatting `ColorComponentField`'s drag/scroll scrub
+    /// uses. Only touches components that actually have a range and are out of it — hex and
+    /// unbounded fields (e.g. Lab a/b) are untouched.
+    private func clampValuesToRange(layout: DecomposedColor) {
+        for (i, component) in layout.components.enumerated() where i < values.count {
+            guard let range = component.range,
+                  let n = Double(values[i].trimmingCharacters(in: .whitespaces))
+            else {
+                continue
+            }
+            let clamped = min(max(n, range.lowerBound), range.upperBound)
+            guard clamped != n else { continue }
+            values[i] = ColorComponentField.formattedDragValue(clamped, kind: component.kind)
+        }
+    }
+
     private func commitEditing() {
         // Called on Return: drop focus, which routes through finishEditing().
         focusedIndex = nil
@@ -273,11 +304,17 @@ struct EditableColorValue: View {
             eyedropper.set(color)
             lastPreviewedColor = eyedropper.color
             NotificationCenter.default.post(name: .colorPicked, object: nil)
-            // Don't resync `values` from the just-committed colour: some formats are lossy at
-            // their extremes (e.g. HSB hue/saturation are undefined at brightness 0), so
-            // decomposing straight back can silently discard what was just typed — e.g. typing
-            // hsb(0, 50%, 0%) round-trips through black and reports back 0% saturation. `values`
-            // already holds exactly what was committed, which is the more faithful thing to show.
+            // `recompose` already clamps an out-of-range number rather than rejecting it (see
+            // `ColorComponent.isValid`); snap the displayed text to match what was actually
+            // used, rather than leaving e.g. a typed "400" showing next to a hue that's
+            // actually 360.
+            clampValuesToRange(layout: layout)
+            // Don't otherwise resync `values` from the just-committed colour: some formats are
+            // lossy at their extremes (e.g. HSB hue/saturation are undefined at brightness 0),
+            // so decomposing straight back can silently discard what was just typed — e.g.
+            // typing hsb(0, 50%, 0%) round-trips through black and reports back 0% saturation.
+            // `values` already holds exactly what was committed, which is the more faithful
+            // thing to show.
             endSession(resync: false)
         } else if let preEditColor {
             eyedropper.set(preEditColor)

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -158,8 +158,8 @@ struct EditableColorValue: View {
         let allValid = zip(layout.components, values).allSatisfy { $0.isValid($1) }
         isInvalid = !allValid
         guard allValid, let color = format.recompose(values, style: style, in: colorSpace) else { return }
-        lastPreviewedColor = color
         eyedropper.set(color)
+        lastPreviewedColor = eyedropper.color
     }
 
     private func commitEditing() {
@@ -171,12 +171,12 @@ struct EditableColorValue: View {
         let layout = decomposed
         let allValid = zip(layout.components, values).allSatisfy { $0.isValid($1) }
         if allValid, let color = format.recompose(values, style: style, in: colorSpace) {
-            lastPreviewedColor = color
             eyedropper.set(color)
+            lastPreviewedColor = eyedropper.color
             NotificationCenter.default.post(name: .colorPicked, object: nil)
         } else if let preEditColor {
-            lastPreviewedColor = preEditColor
             eyedropper.set(preEditColor)
+            lastPreviewedColor = eyedropper.color
         }
         endSession()
     }

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Defaults
 import SwiftUI
 
@@ -175,31 +176,38 @@ struct EditableColorValue: View {
     /// joins that session by moving focus to it, the same way clicking a new field mid-edit does
     /// in `handleFocusChange` — rather than letting a second, session-less drag mutate the shared
     /// `values` array and then tear down the first field's session on release.
+    ///
+    /// A *fresh* session deliberately does NOT set `focusedIndex`: scrubbing (drag or scroll)
+    /// must never focus the real `TextField`, or its AppKit field editor becomes first responder
+    /// and fights the scrub with click-to-edit/select-all behaviour. An unfocused `TextField`
+    /// with a changing `text` binding just renders like a label — no editor involved.
     private func beginDragSession(index: Int, layout: DecomposedColor) {
         if isEditing {
             focusedIndex = index
             return
         }
-        isEditing = true
-        preEditColor = eyedropper.color
-        values = layout.values
-        valuesKey = FormatStyleKey(format: format, style: style)
-        focusedIndex = index
+        startSession(layout: layout)
     }
 
     private func handleFocusChange(to newValue: Int?, layout: DecomposedColor) {
         if newValue != nil {
             // Entering (or moving between) fields — start a session on the first focus.
             if !isEditing {
-                isEditing = true
-                preEditColor = eyedropper.color
-                values = layout.values
-                valuesKey = FormatStyleKey(format: format, style: style)
+                startSession(layout: layout)
             }
         } else if isEditing {
             // Focus left every field (blur / tab-out) — commit if valid, otherwise revert.
             finishEditing()
         }
+    }
+
+    /// Snapshot the colour and working values at the start of an edit or drag session, so
+    /// `finishEditing`/`abortEditingForExternalPick` have a consistent point to commit or revert to.
+    private func startSession(layout: DecomposedColor) {
+        isEditing = true
+        preEditColor = eyedropper.color
+        values = layout.values
+        valuesKey = FormatStyleKey(format: format, style: style)
     }
 
     /// Recompose the working values and preview them live; flag invalid input for the pill.
@@ -257,6 +265,13 @@ struct EditableColorValue: View {
 
 /// A single focusable numeric/hex field styled to the swatch's UI colour, with the four design
 /// states: default (bare), hover (filled), focus (outlined), invalid (dashed outline).
+///
+/// Backed by a custom `NSTextField` (`ScrubTextField`, below) rather than a plain SwiftUI
+/// `TextField`. Three attempts to bolt click-drag-to-scrub onto a native `TextField` via
+/// SwiftUI `DragGesture`/local event monitors all lost the race against AppKit's own
+/// click-to-focus — a raw mouseDown on a real `TextField` always focuses/selects it immediately,
+/// before any gesture recognizer gets a chance to see the drag. Owning `mouseDown` directly is
+/// the only way to decide click-vs-drag *before* anything focuses.
 private struct ColorComponentField: View {
     @Binding var text: String
     let component: ColorComponent
@@ -272,8 +287,10 @@ private struct ColorComponentField: View {
     let onDragEnd: () -> Void
 
     @State private var isHovering = false
-    /// Non-nil while a drag-to-scrub gesture owns this field; holds the value at drag start.
-    @State private var dragOrigin: Double?
+    /// Non-nil while a two-finger scroll-to-scrub gesture owns this field; holds the value at
+    /// scroll start. `scrollAccumulated` tracks total vertical scroll since then.
+    @State private var scrollOrigin: Double?
+    @State private var scrollAccumulated: CGFloat = 0
 
     private var isFocused: Bool { focusedIndex == index }
     private var isInvalid: Bool { isFocused && !component.isValid(text) }
@@ -281,75 +298,85 @@ private struct ColorComponentField: View {
     private var isDraggable: Bool { component.kind != .hex }
 
     var body: some View {
-        TextField("", text: $text)
-            .textFieldStyle(.plain)
-            .font(.system(size: fontSize, weight: .regular))
-            .foregroundStyle(Color(uiColor))
-            .fixedSize()
-            .multilineTextAlignment(.center)
-            .focused($focusedIndex, equals: index)
-            // We already draw a custom focus outline below; the system's own focus ring is wider
-            // than that outline and made focused fields look larger than their neighbours.
-            .focusEffectDisabled()
-            .onSubmit(onSubmit)
-            .onExitCommand(perform: onCancel)
-            .padding(.horizontal, 3)
-            .padding(.vertical, 1)
-            .background(
-                RoundedRectangle(cornerRadius: 5)
-                    .fill(Color(uiColor).opacity(isHovering && !isFocused ? 0.18 : 0))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 5)
-                    .strokeBorder(
-                        Color(uiColor).opacity(isFocused ? 0.9 : 0),
-                        style: StrokeStyle(lineWidth: 1, dash: isInvalid ? [2, 2] : [])
+        ScrubbableColorField(
+            text: $text,
+            fontSize: fontSize,
+            textColor: uiColor,
+            isDraggable: isDraggable,
+            range: component.range,
+            kind: component.kind,
+            isFocused: isFocused,
+            onFocusChange: { focused in focusedIndex = focused ? index : (focusedIndex == index ? nil : focusedIndex) },
+            onSubmit: onSubmit,
+            onCancel: onCancel,
+            onDragBegin: onDragBegin,
+            onDragEnd: onDragEnd
+        )
+        .fixedSize()
+        .padding(.horizontal, 1)
+        .padding(.vertical, 1)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(Color(uiColor).opacity(isHovering && !isFocused ? 0.18 : 0))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 5)
+                .strokeBorder(
+                    Color(uiColor).opacity(isFocused ? 0.9 : 0),
+                    style: StrokeStyle(lineWidth: 1, dash: isInvalid ? [2, 2] : [])
+                )
+        )
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            isHovering = hovering
+            guard !isFocused else { return }
+            // Only show the scrub cursor where scrubbing is actually possible; hex has no
+            // natural min/max to scrub between, so it keeps the ordinary text cursor.
+            if hovering { (isDraggable ? NSCursor.resizeLeftRight : NSCursor.iBeam).set() } else { NSCursor.arrow.set() }
+        }
+        .animation(.easeInOut(duration: 0.12), value: isHovering)
+        .animation(.easeInOut(duration: 0.12), value: isFocused)
+        .background(
+            Group {
+                if isDraggable {
+                    ScrollValueAdapter(
+                        isEnabled: !isFocused,
+                        onScroll: handleScrollDelta,
+                        onScrollEnd: handleScrollEnded
                     )
-            )
-            .contentShape(Rectangle())
-            .onHover { hovering in
-                isHovering = hovering
-                guard isDraggable, !isFocused else { return }
-                if hovering { NSCursor.resizeLeftRight.set() } else { NSCursor.arrow.set() }
+                }
             }
-            .animation(.easeInOut(duration: 0.12), value: isHovering)
-            .animation(.easeInOut(duration: 0.12), value: isFocused)
-            // Only competes with the TextField's own click/drag-to-select while unfocused, so
-            // typing and text selection inside an already-focused field are unaffected.
-            .gesture(
-                DragGesture(minimumDistance: 2)
-                    .onChanged(handleDragChanged)
-                    .onEnded(handleDragEnded),
-                including: isDraggable && !isFocused ? .all : .subviews
-            )
+            .allowsHitTesting(false)
+        )
     }
 
-    /// Click-and-drag left/right nudges the value: 1 unit per pixel, or 0.1 per pixel while
-    /// holding Option for fine adjustment. Clamped to the component's range when it has one.
-    private func handleDragChanged(_ value: DragGesture.Value) {
+    /// Two-finger trackpad scroll nudges the value the same way click-drag does: accumulated
+    /// vertical scroll maps 1 unit per point (0.1 while holding Option), clamped to range.
+    private func handleScrollDelta(_ deltaY: CGFloat) {
         guard isDraggable else { return }
-        if dragOrigin == nil {
-            dragOrigin = Double(text.trimmingCharacters(in: .whitespaces)) ?? 0
-            NSCursor.resizeLeftRight.set()
+        if scrollOrigin == nil {
+            scrollOrigin = Double(text.trimmingCharacters(in: .whitespaces)) ?? 0
+            scrollAccumulated = 0
             onDragBegin()
         }
-        guard let origin = dragOrigin else { return }
+        guard let origin = scrollOrigin else { return }
+        scrollAccumulated += deltaY
         let fine = NSEvent.modifierFlags.contains(.option)
-        var newValue = origin + Double(value.translation.width) * (fine ? 0.1 : 1.0)
+        var newValue = origin + Double(scrollAccumulated) * (fine ? 0.1 : 1.0)
         if let range = component.range {
             newValue = min(max(newValue, range.lowerBound), range.upperBound)
         }
         text = Self.formattedDragValue(newValue, kind: component.kind)
     }
 
-    private func handleDragEnded(_: DragGesture.Value) {
-        guard dragOrigin != nil else { return }
-        dragOrigin = nil
-        NSCursor.arrow.set()
+    private func handleScrollEnded() {
+        guard scrollOrigin != nil else { return }
+        scrollOrigin = nil
+        scrollAccumulated = 0
         onDragEnd()
     }
 
-    private static func formattedDragValue(_ value: Double, kind: ComponentKind) -> String {
+    fileprivate static func formattedDragValue(_ value: Double, kind: ComponentKind) -> String {
         switch kind {
         case .hex:
             return ""
@@ -358,5 +385,307 @@ private struct ColorComponentField: View {
         case .decimal:
             return CGFloat(value).strippedDecimalString(maxDecimalPlaces: 4)
         }
+    }
+}
+
+/// Captures two-finger trackpad scroll events landing within the wrapped view's bounds and
+/// reports vertical delta/end, mirroring `HorizontalScrollWheelAdapter`'s local-monitor approach
+/// so a scrub field can be nudged the same way click-drag nudges it.
+private struct ScrollValueAdapter: NSViewRepresentable {
+    let isEnabled: Bool
+    let onScroll: (CGFloat) -> Void
+    let onScrollEnd: () -> Void
+
+    func makeNSView(context _: Context) -> ScrollCaptureView {
+        let view = ScrollCaptureView()
+        view.isEnabled = isEnabled
+        view.onScroll = onScroll
+        view.onScrollEnd = onScrollEnd
+        return view
+    }
+
+    func updateNSView(_ view: ScrollCaptureView, context _: Context) {
+        view.isEnabled = isEnabled
+        view.onScroll = onScroll
+        view.onScrollEnd = onScrollEnd
+    }
+
+    final class ScrollCaptureView: NSView {
+        var isEnabled = true
+        var onScroll: ((CGFloat) -> Void)?
+        var onScrollEnd: (() -> Void)?
+        private var monitor: Any?
+        private var isScrolling = false
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if window != nil, monitor == nil {
+                monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+                    self?.handle(event) ?? event
+                }
+            } else if window == nil, let monitor {
+                NSEvent.removeMonitor(monitor)
+                self.monitor = nil
+            }
+        }
+
+        deinit {
+            if let monitor { NSEvent.removeMonitor(monitor) }
+        }
+
+        private func handle(_ event: NSEvent) -> NSEvent? {
+            guard isEnabled, event.window === window, let window else { return event }
+
+            // Once we own an in-progress scroll, keep tracking it no matter where the cursor
+            // goes: trackpad momentum keeps delivering events (often with a final `.ended`
+            // phase) after the user's fingers leave the trackpad, and by then the cursor has
+            // frequently drifted off this field. Gating termination on `bounds.contains` meant
+            // that final event was silently dropped, `onScrollEnd` never fired, and the parent's
+            // edit session leaked open — so the *next* field touched would find a stale
+            // "already editing" session and force-focus itself.
+            if isScrolling {
+                if event.phase == .ended || event.phase == .cancelled || event.momentumPhase == .ended {
+                    isScrolling = false
+                    onScrollEnd?()
+                    return event
+                }
+                guard event.hasPreciseScrollingDeltas else { return event }
+                let deltaY = event.scrollingDeltaY
+                guard deltaY != 0 else { return event }
+                onScroll?(deltaY)
+                return nil
+            }
+
+            let pointInSelf = convert(event.locationInWindow, from: nil)
+            guard bounds.contains(pointInSelf) else { return event }
+
+            // Only intervene for trackpad/Magic Mouse gesture scrolling, which carries
+            // phase/precise deltas; classic scroll wheels should keep their default behaviour.
+            guard event.hasPreciseScrollingDeltas else { return event }
+            guard event.phase != .ended, event.phase != .cancelled, event.momentumPhase != .ended else { return event }
+
+            let deltaY = event.scrollingDeltaY
+            guard deltaY != 0 else { return event }
+            isScrolling = true
+            onScroll?(deltaY)
+            return nil
+        }
+    }
+}
+
+/// Wraps `ScrubTextField` (below) for SwiftUI. Owns focus explicitly via `isFocused`/
+/// `onFocusChange` rather than `@FocusState`/`.focused()` (which don't bridge to a custom
+/// `NSViewRepresentable`), synced through the field's own `NSTextFieldDelegate` callbacks so it
+/// stays correct however focus changes — click, Tab, or a programmatic request.
+private struct ScrubbableColorField: NSViewRepresentable {
+    @Binding var text: String
+    let fontSize: CGFloat
+    let textColor: NSColor
+    let isDraggable: Bool
+    let range: ClosedRange<Double>?
+    let kind: ComponentKind
+    let isFocused: Bool
+    let onFocusChange: (Bool) -> Void
+    let onSubmit: () -> Void
+    let onCancel: () -> Void
+    /// Fired when a click-drag-to-scrub gesture starts/ends, so the parent can wrap it in the
+    /// same live-preview/commit session used for typed edits.
+    let onDragBegin: () -> Void
+    let onDragEnd: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, onSubmit: onSubmit, onCancel: onCancel, onFocusChange: onFocusChange)
+    }
+
+    func makeNSView(context: Context) -> ScrubTextField {
+        let field = ScrubTextField()
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.alignment = .center
+        field.usesSingleLineMode = true
+        field.cell?.wraps = false
+        field.delegate = context.coordinator
+        field.font = NSFont.systemFont(ofSize: fontSize, weight: .regular)
+        field.stringValue = text
+        return field
+    }
+
+    func updateNSView(_ nsView: ScrubTextField, context: Context) {
+        context.coordinator.text = $text
+        if nsView.font?.pointSize != fontSize {
+            nsView.font = NSFont.systemFont(ofSize: fontSize, weight: .regular)
+            nsView.invalidateIntrinsicContentSize()
+        }
+        nsView.textColor = textColor
+        nsView.isDraggable = isDraggable
+        nsView.range = range
+        nsView.kind = kind
+        nsView.onDragBegin = onDragBegin
+        nsView.onDragChanged = { [weak nsView] newValue in
+            nsView?.stringValue = ColorComponentField.formattedDragValue(newValue, kind: kind)
+            text = nsView?.stringValue ?? text
+        }
+        nsView.onDragEnd = onDragEnd
+
+        if nsView.stringValue != text {
+            nsView.stringValue = text
+            nsView.invalidateIntrinsicContentSize()
+            // A programmatic change (drag/scroll, or an external colour landing mid-edit) while
+            // this field is still first responder — keep the caret collapsed at the end rather
+            // than whatever AppKit does by default when `stringValue` changes underneath it.
+            if let editor = nsView.currentEditor() as? NSTextView {
+                let length = (text as NSString).length
+                editor.selectedRange = NSRange(location: length, length: 0)
+            }
+        }
+
+        let editorIsActive = nsView.currentEditor() != nil && nsView.window?.firstResponder === nsView.currentEditor()
+        if isFocused, !editorIsActive {
+            nsView.window?.makeFirstResponder(nsView)
+        } else if !isFocused, editorIsActive {
+            nsView.window?.makeFirstResponder(nil)
+        }
+    }
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var text: Binding<String>
+        let onSubmit: () -> Void
+        let onCancel: () -> Void
+        let onFocusChange: (Bool) -> Void
+
+        init(text: Binding<String>, onSubmit: @escaping () -> Void, onCancel: @escaping () -> Void, onFocusChange: @escaping (Bool) -> Void) {
+            self.text = text
+            self.onSubmit = onSubmit
+            self.onCancel = onCancel
+            self.onFocusChange = onFocusChange
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSTextField else { return }
+            text.wrappedValue = field.stringValue
+        }
+
+        func controlTextDidBeginEditing(_: Notification) { onFocusChange(true) }
+        func controlTextDidEndEditing(_: Notification) { onFocusChange(false) }
+
+        func control(_: NSControl, textView _: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+                onSubmit()
+                return true
+            }
+            if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                onCancel()
+                return true
+            }
+            return false
+        }
+    }
+}
+
+/// A plain `NSTextField` subclass that owns its own `mouseDown`, so click-vs-drag is resolved
+/// *before* anything can focus — no second view or event monitor racing the field's native click
+/// handling. A resolved drag never touches first-responder status at all, so the field just
+/// displays a changing string like a label while scrubbing (no editor, no selection, no caret).
+/// A resolved click focuses normally; `becomeFirstResponder` then deterministically collapses
+/// AppKit's default select-all in the same call stack, rather than reacting to it after the fact.
+private final class ScrubTextField: NSTextField {
+    var isDraggable = false
+    var range: ClosedRange<Double>?
+    var kind: ComponentKind = .integer
+    var onDragBegin: (() -> Void)?
+    var onDragChanged: ((Double) -> Void)?
+    var onDragEnd: (() -> Void)?
+
+    private var dragOrigin: Double?
+
+    // The default NSTextFieldCell intrinsic size proved unreliable once `.fixedSize()` queried
+    // it eagerly (fields collapsed to ~0pt wide) — compute it directly from the string and font
+    // instead of trusting the cell's own layout pass.
+    override var intrinsicContentSize: NSSize {
+        let currentFont = font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
+        let size = (stringValue as NSString).size(withAttributes: [.font: currentFont])
+        return NSSize(width: ceil(size.width) + 2, height: ceil(size.height))
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+        if result, let editor = currentEditor() {
+            let length = (editor.string as NSString).length
+            editor.selectedRange = NSRange(location: length, length: 0)
+        }
+        return result
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard isDraggable else {
+            super.mouseDown(with: event)
+            return
+        }
+
+        let startPoint = event.locationInWindow
+        var didBeginDrag = false
+        let threshold: CGFloat = 2
+
+        // Every exit path below must resolve exactly one of "focus" or a paired
+        // onDragBegin/onDragEnd — an orphaned "began but never ended" session would leave the
+        // parent's edit session stuck open, making the next interaction silently join it instead
+        // of starting fresh.
+        while true {
+            guard let next = NSApp.nextEvent(
+                matching: [.leftMouseDragged, .leftMouseUp],
+                until: .distantFuture,
+                inMode: .eventTracking,
+                dequeue: true
+            ) else {
+                if didBeginDrag { finishDrag() }
+                return
+            }
+
+            switch next.type {
+            case .leftMouseDragged:
+                let translationX = next.locationInWindow.x - startPoint.x
+                if !didBeginDrag {
+                    guard abs(translationX) >= threshold else { continue }
+                    didBeginDrag = true
+                    beginDrag()
+                }
+                updateDrag(translationX: translationX)
+            case .leftMouseUp:
+                if didBeginDrag {
+                    finishDrag()
+                } else {
+                    // A genuine click: focus normally, exactly like a plain click on any
+                    // ordinary text field would.
+                    window?.makeFirstResponder(self)
+                }
+                return
+            default:
+                if didBeginDrag { finishDrag() }
+                return
+            }
+        }
+    }
+
+    private func beginDrag() {
+        dragOrigin = Double(stringValue.trimmingCharacters(in: .whitespaces)) ?? 0
+        NSCursor.resizeLeftRight.set()
+        onDragBegin?()
+    }
+
+    private func updateDrag(translationX: CGFloat) {
+        guard let origin = dragOrigin else { return }
+        let fine = NSEvent.modifierFlags.contains(.option)
+        var newValue = origin + Double(translationX) * (fine ? 0.1 : 1.0)
+        if let range {
+            newValue = min(max(newValue, range.lowerBound), range.upperBound)
+        }
+        onDragChanged?(newValue)
+    }
+
+    private func finishDrag() {
+        dragOrigin = nil
+        NSCursor.arrow.set()
+        onDragEnd?()
     }
 }

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -590,8 +590,18 @@ private struct ScrubbableColorField: NSViewRepresentable {
         nsView.kind = kind
         nsView.onDragBegin = onDragBegin
         nsView.onDragChanged = { [weak nsView] newValue in
-            nsView?.stringValue = ColorComponentField.formattedDragValue(newValue, kind: kind)
-            text = nsView?.stringValue ?? text
+            guard let nsView else { return }
+            nsView.stringValue = ColorComponentField.formattedDragValue(newValue, kind: kind)
+            // Setting `stringValue` on a field that still has a live field editor attached
+            // (see `beginDrag`'s comment) resets the editor's selection to select-all every
+            // time — so every step of the drag re-selects the newly-set text, and whichever
+            // step happens to be the last one is what's left visibly selected once the drag
+            // ends. Collapse it again after every step, not just the first.
+            if let editor = nsView.currentEditor() {
+                let length = (editor.string as NSString).length
+                editor.selectedRange = NSRange(location: length, length: 0)
+            }
+            text = nsView.stringValue
         }
         nsView.onDragEnd = onDragEnd
 

--- a/Pika/Views/EditableColorValue.swift
+++ b/Pika/Views/EditableColorValue.swift
@@ -46,6 +46,10 @@ struct EditableColorValue: View {
     @State private var values: [String] = []
     @State private var isEditing = false
     @State private var preEditColor: NSColor?
+    /// The colour we last pushed to `eyedropper` ourselves (live preview or commit). Lets
+    /// `onChange(of: eyedropper.color)` tell our own writes apart from an external pick landing
+    /// mid-edit, so the latter can abort the session instead of being silently overwritten.
+    @State private var lastPreviewedColor: NSColor?
     @FocusState private var focusedIndex: Int?
 
     private var decomposed: DecomposedColor {
@@ -96,7 +100,15 @@ struct EditableColorValue: View {
         .onPreferenceChange(EditableWidthKey.self) { width = $0 }
         .onAppear { syncValuesFromColor(layout) }
         .onChange(of: focusedIndex) { newValue in handleFocusChange(to: newValue, layout: layout) }
-        .onChange(of: eyedropper.color) { _ in if !isEditing { syncValuesFromColor(decomposed) } }
+        .onChange(of: eyedropper.color) { newValue in
+            if isEditing {
+                // A change we didn't push ourselves is an external pick landing mid-edit —
+                // abort the session so the external colour wins, matching pre-edit behaviour.
+                if newValue != lastPreviewedColor { abortEditingForExternalPick() }
+            } else {
+                syncValuesFromColor(decomposed)
+            }
+        }
         .onChange(of: format) { _ in if !isEditing { syncValuesFromColor(decomposed) } }
         .onChange(of: style) { _ in if !isEditing { syncValuesFromColor(decomposed) } }
     }
@@ -146,6 +158,7 @@ struct EditableColorValue: View {
         let allValid = zip(layout.components, values).allSatisfy { $0.isValid($1) }
         isInvalid = !allValid
         guard allValid, let color = format.recompose(values, style: style, in: colorSpace) else { return }
+        lastPreviewedColor = color
         eyedropper.set(color)
     }
 
@@ -158,16 +171,28 @@ struct EditableColorValue: View {
         let layout = decomposed
         let allValid = zip(layout.components, values).allSatisfy { $0.isValid($1) }
         if allValid, let color = format.recompose(values, style: style, in: colorSpace) {
+            lastPreviewedColor = color
             eyedropper.set(color)
             NotificationCenter.default.post(name: .colorPicked, object: nil)
         } else if let preEditColor {
+            lastPreviewedColor = preEditColor
             eyedropper.set(preEditColor)
         }
         endSession()
     }
 
     private func revertEditing() {
-        if let preEditColor { eyedropper.set(preEditColor) }
+        if let preEditColor {
+            lastPreviewedColor = preEditColor
+            eyedropper.set(preEditColor)
+        }
+        focusedIndex = nil
+        endSession()
+    }
+
+    /// An external eyedropper pick landed while a field was focused — abort the edit so the
+    /// pick wins, rather than letting a later blur silently overwrite it with typed values.
+    private func abortEditingForExternalPick() {
         focusedIndex = nil
         endSession()
     }
@@ -176,6 +201,7 @@ struct EditableColorValue: View {
         isEditing = false
         isInvalid = false
         preEditColor = nil
+        lastPreviewedColor = nil
         values = decomposed.values
     }
 }

--- a/Pika/Views/EyedropperButton.swift
+++ b/Pika/Views/EyedropperButton.swift
@@ -1,5 +1,70 @@
+import AppKit
 import Defaults
 import SwiftUI
+
+/// The full-size background pick target: owns its own `mouseDown` (mirroring `ScrubTextField`'s
+/// approach in `EditableColorValue.swift`) so it can check the window's first responder *before*
+/// deciding what a click means. A plain SwiftUI `Button` can't make that distinction — its action
+/// fires unconditionally on tap, so a click intended to dismiss a focused colour-value field would
+/// also fall through and start a new pick. If a field is currently being edited, this click's only
+/// job is to end that edit (matching standard click-away-to-blur behaviour); otherwise it starts
+/// a pick, same as before.
+private struct PickTarget: NSViewRepresentable {
+    let onPick: () -> Void
+    let onPressChange: (Bool) -> Void
+    /// Called instead of `onPick` when the click's only job is to end an active edit session.
+    /// AppKit's own `endEditing(for:)` resigns the field editor, but doesn't reliably notify
+    /// `EditableColorValue`'s own focus-tracking state back up (its outline stays stuck showing
+    /// "focused") — so the parent also needs an explicit nudge to clear that state itself.
+    let onDismissEditing: () -> Void
+
+    func makeNSView(context _: Context) -> PickTargetView {
+        let view = PickTargetView()
+        view.onPick = onPick
+        view.onPressChange = onPressChange
+        view.onDismissEditing = onDismissEditing
+        return view
+    }
+
+    func updateNSView(_ view: PickTargetView, context _: Context) {
+        view.onPick = onPick
+        view.onPressChange = onPressChange
+        view.onDismissEditing = onDismissEditing
+    }
+
+    final class PickTargetView: NSView {
+        var onPick: (() -> Void)?
+        var onPressChange: ((Bool) -> Void)?
+        var onDismissEditing: (() -> Void)?
+
+        override func mouseDown(with _: NSEvent) {
+            if window?.firstResponder is NSText {
+                window?.endEditing(for: nil)
+                onDismissEditing?()
+                return
+            }
+
+            onPressChange?(true)
+            while true {
+                guard let next = NSApp.nextEvent(
+                    matching: [.leftMouseDragged, .leftMouseUp],
+                    until: .distantFuture,
+                    inMode: .eventTracking,
+                    dequeue: true
+                ) else {
+                    onPressChange?(false)
+                    return
+                }
+                if next.type == .leftMouseUp {
+                    let point = convert(next.locationInWindow, from: nil)
+                    onPressChange?(false)
+                    if bounds.contains(point) { onPick?() }
+                    return
+                }
+            }
+        }
+    }
+}
 
 struct EyedropperButton: View {
     @ObservedObject var eyedropper: Eyedropper
@@ -14,20 +79,26 @@ struct EyedropperButton: View {
     @State private var hoverTask: Task<Void, Never>?
     @State private var childHovered: Bool = false
     @State private var valueInvalid: Bool = false
+    @State private var isPressed: Bool = false
+    @State private var dismissEditingTrigger: Int = 0
+    @State private var flashOpacity: Double = 0
 
     var body: some View {
         ZStack {
             // Background pick target: a click anywhere that isn't the editable value (or the
-            // non-interactive labels above it, which fall through) starts a pick.
-            Button(action: {
-                NSApp.sendAction(eyedropper.type.pickSelector, to: nil, from: nil)
-            }, label: {
-                Color.clear
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .contentShape(Rectangle())
-            })
-            .buttonStyle(EyedropperButtonStyle(color: Color(eyedropper.color)))
-            .focusable(false)
+            // non-interactive labels above it, which fall through) starts a pick — unless a
+            // colour-value field is currently focused, in which case it just dismisses that
+            // field. See `PickTarget` above.
+            PickTarget(
+                onPick: { NSApp.sendAction(eyedropper.type.pickSelector, to: nil, from: nil) },
+                onPressChange: { isPressed = $0 },
+                onDismissEditing: { dismissEditingTrigger += 1 }
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(eyedropper.color))
+            .opacity(isPressed ? 0.8 : 1.0)
+            .animation(.easeIn(duration: 0.15), value: Color(eyedropper.color))
+            .animation(.easeIn(duration: 0.15), value: isPressed)
 
             // Content overlay, lifted out of the pick button so the value's fields receive
             // clicks. The type label and colour name disable hit-testing so clicks fall
@@ -73,7 +144,8 @@ struct EyedropperButton: View {
                         format: colorFormat,
                         style: copyFormat,
                         colorSpace: colorSpace,
-                        isInvalid: $valueInvalid
+                        isInvalid: $valueInvalid,
+                        dismissEditingTrigger: dismissEditingTrigger
                     )
                     .padding(.trailing, 32.0)
 
@@ -133,6 +205,19 @@ struct EyedropperButton: View {
             }
             .padding(.all, 8.0)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+
+            // Subtle affordance for a genuine screen pick landing on this swatch — most useful
+            // mid pick-pair, where it's otherwise a silent colour swap with nothing to tell you
+            // "that was the foreground" versus "that was the background".
+            Color.white
+                .opacity(flashOpacity)
+                .allowsHitTesting(false)
+        }
+        .onReceive(eyedropper.pickFlash) {
+            flashOpacity = 0.35
+            withAnimation(.easeOut(duration: 0.35)) {
+                flashOpacity = 0
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
             colorSpace = Defaults[.colorSpace]

--- a/Pika/Views/EyedropperButton.swift
+++ b/Pika/Views/EyedropperButton.swift
@@ -68,6 +68,12 @@ private struct PickTarget: NSViewRepresentable {
 
 struct EyedropperButton: View {
     @ObservedObject var eyedropper: Eyedropper
+    /// Shared with the other swatch (owned by `ColorPickers`) rather than local: a click on
+    /// *this* swatch's `PickTarget` can be dismissing a field focused on the *other* swatch,
+    /// since the first-responder check that decides "dismiss vs. pick" is window-wide, not
+    /// scoped to this button. Bumping a trigger only this button's own `EditableColorValue`
+    /// hears would silently drop that edit instead of committing or reverting it.
+    @Binding var dismissEditingTrigger: Int
     @Default(.colorFormat) var colorFormat
     @Default(.copyFormat) var copyFormat
     @Default(.hideColorNames) var hideColorNames
@@ -80,7 +86,6 @@ struct EyedropperButton: View {
     @State private var childHovered: Bool = false
     @State private var valueInvalid: Bool = false
     @State private var isPressed: Bool = false
-    @State private var dismissEditingTrigger: Int = 0
     @State private var flashOpacity: Double = 0
 
     var body: some View {
@@ -242,7 +247,8 @@ struct EyedropperButton: View {
 struct EyedropperButton_Previews: PreviewProvider {
     static var previews: some View {
         EyedropperButton(
-            eyedropper: Eyedropper(type: .foreground, color: PikaConstants.initialColors.randomElement()!)
+            eyedropper: Eyedropper(type: .foreground, color: PikaConstants.initialColors.randomElement()!),
+            dismissEditingTrigger: .constant(0)
         )
         .frame(width: 170.0)
     }

--- a/Pika/Views/EyedropperButton.swift
+++ b/Pika/Views/EyedropperButton.swift
@@ -37,7 +37,7 @@ struct EyedropperButton: View {
                 // preview-pill overlap) so labels fade out as the window shrinks and return
                 // when it grows again. The invalid pill overrides the fade so it's never hidden.
                 let showsTypeLabel = adaptive.showsTypeLabels
-                HStack(spacing: 6.0) {
+                HStack(alignment: .firstTextBaseline, spacing: 6.0) {
                     Text(eyedropper.type.description)
                         .font(.caption)
                         .fontWeight(.semibold)
@@ -45,6 +45,16 @@ struct EyedropperButton: View {
                     if valueInvalid {
                         InvalidInputPill(uiColor: eyedropper.color.getUIColor())
                     }
+                    // Reserves the pill's height in this row at all times (zero width, so it
+                    // never otherwise affects layout) so toggling the pill doesn't change the
+                    // row's height. The content below is anchored `.bottomLeading` in its parent
+                    // frame, so any height change here shifts this label — the "Foreground" /
+                    // "Background" text visibly jumping by a pixel each time invalid state was
+                    // entered or exited.
+                    InvalidInputPill(uiColor: .clear)
+                        .fixedSize()
+                        .frame(width: 0)
+                        .accessibilityHidden(true)
                 }
                 .opacity(showsTypeLabel || valueInvalid ? 1 : 0)
                 .animation(

--- a/Pika/Views/EyedropperButton.swift
+++ b/Pika/Views/EyedropperButton.swift
@@ -1,50 +1,6 @@
 import Defaults
 import SwiftUI
 
-private struct ValueWidthKey: PreferenceKey {
-    static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) { value = nextValue() }
-}
-
-/// The colour value, shrunk to fit two lines as its column narrows. The font size is
-/// computed deterministically from the (font-independent) column width, so — unlike
-/// `minimumScaleFactor` + `lineLimit` — the wrap can't oscillate between one and two
-/// lines during a resize.
-struct AdaptiveValueText: View {
-    let value: String
-    let color: Color
-    private let baseSize: CGFloat = 18
-    private let minSize: CGFloat = 11
-    @State private var width: CGFloat = 0
-
-    private var fontSize: CGFloat {
-        guard width > 4 else { return baseSize }
-        let full = (value as NSString).size(withAttributes: [.font: NSFont.systemFont(ofSize: baseSize)]).width
-        guard full > 0 else { return baseSize }
-        // Scale the font *proportionally* with the column width so the wrap point stays
-        // put as the window resizes — no bistable jumping. The 1.5 factor (vs a
-        // theoretical 2 for two full lines) leaves slack for word-boundary wrapping, so
-        // long values still fit two lines instead of spilling to a truncated third.
-        let scale = min(1, (1.5 * width) / full)
-        return max(minSize, baseSize * scale)
-    }
-
-    var body: some View {
-        Text(value)
-            .foregroundStyle(color)
-            .font(.system(size: fontSize, weight: .regular))
-            .lineLimit(2)
-            .truncationMode(.tail)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                GeometryReader { geo in
-                    Color.clear.preference(key: ValueWidthKey.self, value: geo.size.width)
-                }
-            )
-            .onPreferenceChange(ValueWidthKey.self) { width = $0 }
-    }
-}
-
 struct EyedropperButton: View {
     @ObservedObject var eyedropper: Eyedropper
     @Default(.colorFormat) var colorFormat
@@ -57,60 +13,76 @@ struct EyedropperButton: View {
     @State private var colorSpace = Defaults[.colorSpace]
     @State private var hoverTask: Task<Void, Never>?
     @State private var childHovered: Bool = false
+    @State private var valueInvalid: Bool = false
 
     var body: some View {
         ZStack {
+            // Background pick target: a click anywhere that isn't the editable value (or the
+            // non-interactive labels above it, which fall through) starts a pick.
             Button(action: {
                 NSApp.sendAction(eyedropper.type.pickSelector, to: nil, from: nil)
             }, label: {
-                ZStack {
-                    VStack(alignment: .leading, spacing: 2.0) {
-                        // Visibility is size-aware (`adaptive.showsTypeLabels` already
-                        // folds in the preview-pill overlap) so labels fade out as the
-                        // window shrinks and return when it grows again.
-                        let showsTypeLabel = adaptive.showsTypeLabels
-                        Text(eyedropper.type.description)
-                            .font(.caption)
-                            .fontWeight(.semibold)
-                            .foregroundStyle(eyedropper.color.getUIColor().opacity(0.75))
-                            .opacity(showsTypeLabel ? 1 : 0)
-                            .animation(
-                                showsTypeLabel
-                                    ? .easeInOut(duration: 0.25).delay(0.3)
-                                    : .easeInOut(duration: 0.2),
-                                value: showsTypeLabel
-                            )
-
-                        VStack(alignment: .leading, spacing: 6.0) {
-                            // Trailing gutter keeps the value clear of the copy /
-                            // system-picker hover buttons; the value itself shrinks to fit
-                            // two lines (see AdaptiveValueText).
-                            AdaptiveValueText(
-                                value: (eyedropper.color.usingColorSpace(colorSpace) ?? eyedropper.color)
-                                    .toFormat(format: colorFormat, style: copyFormat),
-                                color: Color(eyedropper.color.getUIColor())
-                            )
-                            .padding(.trailing, 32.0)
-
-                            if !hideColorNames, adaptive.showsColorNames {
-                                Text(eyedropper.getClosestColor())
-                                    .font(.system(size: 12, weight: .medium))
-                                    .foregroundStyle(eyedropper.color.getUIColor())
-                            }
-                        }
-                    }
-                    .padding(.all, 10.0)
-                    .modify {
-                        let shadowColor: Color = eyedropper.color.getUIColor() == .white ? .black : .white
-                        $0
-                            .shadow(color: shadowColor.opacity(0.30), radius: 0, x: 0, y: 1)
-                            .shadow(color: shadowColor.opacity(0.10), radius: 3, x: 0, y: 0)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
-                }
+                Color.clear
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
             })
             .buttonStyle(EyedropperButtonStyle(color: Color(eyedropper.color)))
             .focusable(false)
+
+            // Content overlay, lifted out of the pick button so the value's fields receive
+            // clicks. The type label and colour name disable hit-testing so clicks fall
+            // through to the pick button behind them.
+            VStack(alignment: .leading, spacing: 2.0) {
+                // Visibility is size-aware (`adaptive.showsTypeLabels` already folds in the
+                // preview-pill overlap) so labels fade out as the window shrinks and return
+                // when it grows again. The invalid pill overrides the fade so it's never hidden.
+                let showsTypeLabel = adaptive.showsTypeLabels
+                HStack(spacing: 6.0) {
+                    Text(eyedropper.type.description)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(eyedropper.color.getUIColor().opacity(0.75))
+                    if valueInvalid {
+                        InvalidInputPill(uiColor: eyedropper.color.getUIColor())
+                    }
+                }
+                .opacity(showsTypeLabel || valueInvalid ? 1 : 0)
+                .animation(
+                    showsTypeLabel
+                        ? .easeInOut(duration: 0.25).delay(0.3)
+                        : .easeInOut(duration: 0.2),
+                    value: showsTypeLabel
+                )
+                .allowsHitTesting(false)
+
+                VStack(alignment: .leading, spacing: 6.0) {
+                    // Trailing gutter keeps the value clear of the copy / system-picker hover
+                    // buttons; the value shrinks to fit as its column narrows.
+                    EditableColorValue(
+                        eyedropper: eyedropper,
+                        format: colorFormat,
+                        style: copyFormat,
+                        colorSpace: colorSpace,
+                        isInvalid: $valueInvalid
+                    )
+                    .padding(.trailing, 32.0)
+
+                    if !hideColorNames, adaptive.showsColorNames {
+                        Text(eyedropper.getClosestColor())
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(eyedropper.color.getUIColor())
+                            .allowsHitTesting(false)
+                    }
+                }
+            }
+            .padding(.all, 10.0)
+            .modify {
+                let shadowColor: Color = eyedropper.color.getUIColor() == .white ? .black : .white
+                $0
+                    .shadow(color: shadowColor.opacity(0.30), radius: 0, x: 0, y: 1)
+                    .shadow(color: shadowColor.opacity(0.10), radius: 3, x: 0, y: 0)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
 
             VStack(spacing: 4.0) {
                 Button(action: {

--- a/Pika/Views/EyedropperItem.swift
+++ b/Pika/Views/EyedropperItem.swift
@@ -11,13 +11,14 @@ public extension NSPopUpButtonCell {
 struct EyedropperItem: View {
     @Environment(\.colorScheme) var colorScheme: ColorScheme
     @ObservedObject var eyedropper: Eyedropper
+    @Binding var dismissEditingTrigger: Int
     @State private var showToast: Bool = false
     @Default(.colorFormat) var colorFormat
     @Default(.copyFormat) var copyFormat
     let pasteboard = NSPasteboard.general
     var body: some View {
         ZStack {
-            EyedropperButton(eyedropper: eyedropper)
+            EyedropperButton(eyedropper: eyedropper, dismissEditingTrigger: $dismissEditingTrigger)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .onReceive(NotificationCenter.default.publisher(for: eyedropper.type.pickNotification)) { note in
                     let requestedChain = note.userInfo?["chain"] as? Bool == true
@@ -88,7 +89,10 @@ struct EyedropperItem: View {
 
 struct EyedropperItem_Previews: PreviewProvider {
     static var previews: some View {
-        EyedropperItem(eyedropper: Eyedropper(type: .foreground, color: NSColor.black))
-            .frame(width: 180.0)
+        EyedropperItem(
+            eyedropper: Eyedropper(type: .foreground, color: NSColor.black),
+            dismissEditingTrigger: .constant(0)
+        )
+        .frame(width: 180.0)
     }
 }

--- a/Pika/Views/PickerLoupeView.swift
+++ b/Pika/Views/PickerLoupeView.swift
@@ -398,11 +398,20 @@ struct LoupeReadoutCard: View {
     private let cardWidth: CGFloat = 240
 
     // Colours stacked so each gets the full width — plenty of room for the value and name.
+    // Foreground always sits on top: `sampleColor` is whichever type is currently being
+    // picked, so during a chained pick's background leg that would otherwise put background
+    // above foreground, flipping the order the two colours read in between the two legs of
+    // the same pick.
     var body: some View {
+        let samplePanel = panel(viewModel.sampleColor, name: viewModel.colorName)
+        let comparisonPanel = viewModel.comparison.map { panel($0, name: viewModel.comparisonName) }
         VStack(spacing: 0) {
-            panel(viewModel.sampleColor, name: viewModel.colorName)
-            if let comparison = viewModel.comparison {
-                panel(comparison, name: viewModel.comparisonName)
+            if viewModel.target == .foreground {
+                samplePanel
+                comparisonPanel
+            } else {
+                comparisonPanel
+                samplePanel
             }
         }
         .frame(width: cardWidth)

--- a/PikaTests/ColorDecompositionTests.swift
+++ b/PikaTests/ColorDecompositionTests.swift
@@ -95,8 +95,10 @@ final class ColorDecompositionTests: XCTestCase {
         let c = ColorComponent(value: "128", kind: .integer, range: 0 ... 255)
         XCTAssertTrue(c.isValid("0"))
         XCTAssertTrue(c.isValid("255"))
-        XCTAssertFalse(c.isValid("256"))
-        XCTAssertFalse(c.isValid("-1"))
+        // Out-of-range numbers are still valid input — they're clamped to the nearest bound on
+        // commit (see `EditableColorValue.clampValuesToRange`) rather than rejected outright.
+        XCTAssertTrue(c.isValid("256"))
+        XCTAssertTrue(c.isValid("-1"))
         XCTAssertFalse(c.isValid("12.5"))
         XCTAssertFalse(c.isValid("abc"))
         XCTAssertFalse(c.isValid(""))
@@ -123,6 +125,15 @@ final class ColorDecompositionTests: XCTestCase {
         XCTAssertTrue(c.isValid("-12.5"))
         XCTAssertTrue(c.isValid("100"))
         XCTAssertFalse(c.isValid("abc"))
+    }
+
+    // Same "clamped, not rejected" rule as `.integer` — see test_componentValidity_integerRange.
+    func test_componentValidity_decimalRange() {
+        let c = ColorComponent(value: "0.5", kind: .decimal, range: 0 ... 1)
+        XCTAssertTrue(c.isValid("0"))
+        XCTAssertTrue(c.isValid("1"))
+        XCTAssertTrue(c.isValid("1.5"))
+        XCTAssertTrue(c.isValid("-0.5"))
     }
 
     // `Double("inf")`/`Double("nan")` parse successfully but aren't valid colour values — a nil

--- a/PikaTests/ColorDecompositionTests.swift
+++ b/PikaTests/ColorDecompositionTests.swift
@@ -1,0 +1,119 @@
+import Defaults
+@testable import Pika
+import XCTest
+
+final class ColorDecompositionTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // Pin the display space so decompose (which reads Defaults[.colorSpace] for
+        // rgb/hsb/hsl) is deterministic and matches toFormat.
+        Defaults[.colorSpace] = .sRGB
+    }
+
+    private let samples = ["3A7BD5", "E32C88", "000000", "FFFFFF", "808080", "FF8800", "00FF00", "123456"]
+    private var space: NSColorSpace { Defaults[.colorSpace] }
+
+    // MARK: - Parity: decompose(...).joined() must equal toFormat(...)
+
+    func test_decompose_joined_matchesToFormat_forEveryFormatAndStyle() {
+        for hex in samples {
+            let color = NSColor(hex: hex)
+            for format in ColorFormat.allCases {
+                for style in CopyFormat.allCases {
+                    let expected = color.toFormat(format: format, style: style)
+                    let decomposed = format.decompose(color, style: style, in: space)
+                    XCTAssertEqual(
+                        decomposed.joined(), expected,
+                        "Parity failed for \(hex) format=\(format) style=\(style)"
+                    )
+                }
+            }
+        }
+    }
+
+    func test_decompose_componentCount_isOneForHex_threeOtherwise() {
+        let color = NSColor(hex: "3A7BD5")
+        for style in CopyFormat.allCases {
+            XCTAssertEqual(ColorFormat.hex.decompose(color, style: style, in: space).components.count, 1)
+            for format in ColorFormat.allCases where format != .hex {
+                XCTAssertEqual(
+                    format.decompose(color, style: style, in: space).components.count, 3,
+                    "\(format)/\(style) should have 3 components"
+                )
+            }
+        }
+    }
+
+    // MARK: - Round-trip: decompose → recompose lands on (near) the same colour
+
+    func test_decompose_recompose_roundTrip_withinTolerance() {
+        for hex in samples {
+            let color = NSColor(hex: hex)
+            for format in ColorFormat.allCases {
+                for style in CopyFormat.allCases {
+                    let decomposed = format.decompose(color, style: style, in: space)
+                    guard let rebuilt = format.recompose(decomposed.values, style: style, in: space) else {
+                        XCTFail("recompose returned nil for \(hex) \(format)/\(style)")
+                        continue
+                    }
+                    let o = color.toRGBAComponents(in: .sRGB)
+                    let r = rebuilt.toRGBAComponents(in: .sRGB)
+                    // hex/rgb are exact 8-bit; hsb/hsl/lab/oklch snap by up to ~1 display unit.
+                    let tol: CGFloat = (format == .hex || format == .rgb) ? 0.01 : 0.02
+                    XCTAssertEqual(r.r, o.r, accuracy: tol, "R \(hex) \(format)/\(style)")
+                    XCTAssertEqual(r.g, o.g, accuracy: tol, "G \(hex) \(format)/\(style)")
+                    XCTAssertEqual(r.b, o.b, accuracy: tol, "B \(hex) \(format)/\(style)")
+                }
+            }
+        }
+    }
+
+    // MARK: - recompose rejects bad input
+
+    func test_recompose_nonNumeric_returnsNil() {
+        XCTAssertNil(ColorFormat.rgb.recompose(["255", "abc", "0"], style: .css, in: space))
+        XCTAssertNil(ColorFormat.hsl.recompose(["", "50", "50"], style: .css, in: space))
+        XCTAssertNil(ColorFormat.hex.recompose(["nothex"], style: .css, in: space))
+    }
+
+    func test_recompose_wrongComponentCount_returnsNil() {
+        XCTAssertNil(ColorFormat.rgb.recompose(["255", "0"], style: .css, in: space))
+        XCTAssertNil(ColorFormat.oklch.recompose(["50"], style: .css, in: space))
+    }
+
+    func test_recompose_outOfRange_clampsRatherThanFails() {
+        // Over-range ints still produce a colour (clamped), not nil.
+        let white = ColorFormat.rgb.recompose(["999", "999", "999"], style: .css, in: space)
+        XCTAssertNotNil(white)
+        let rgba = white!.toRGBAComponents(in: .sRGB)
+        XCTAssertEqual(rgba.r, 1.0, accuracy: 0.01)
+    }
+
+    // MARK: - ColorComponent validity
+
+    func test_componentValidity_integerRange() {
+        let c = ColorComponent(value: "128", kind: .integer, range: 0 ... 255)
+        XCTAssertTrue(c.isValid("0"))
+        XCTAssertTrue(c.isValid("255"))
+        XCTAssertFalse(c.isValid("256"))
+        XCTAssertFalse(c.isValid("-1"))
+        XCTAssertFalse(c.isValid("12.5"))
+        XCTAssertFalse(c.isValid("abc"))
+        XCTAssertFalse(c.isValid(""))
+    }
+
+    func test_componentValidity_hex() {
+        let c = ColorComponent(value: "ff0000", kind: .hex, range: nil)
+        XCTAssertTrue(c.isValid("ff0000"))
+        XCTAssertTrue(c.isValid("F00"))
+        XCTAssertFalse(c.isValid("ff00"))
+        XCTAssertFalse(c.isValid("gggggg"))
+    }
+
+    func test_componentValidity_decimalUnbounded() {
+        let c = ColorComponent(value: "-12.5", kind: .decimal, range: nil)
+        XCTAssertTrue(c.isValid("-12.5"))
+        XCTAssertTrue(c.isValid("100"))
+        XCTAssertFalse(c.isValid("abc"))
+    }
+}

--- a/PikaTests/ColorDecompositionTests.swift
+++ b/PikaTests/ColorDecompositionTests.swift
@@ -110,10 +110,32 @@ final class ColorDecompositionTests: XCTestCase {
         XCTAssertFalse(c.isValid("gggggg"))
     }
 
+    // Regression test: pasting a hex value with surrounding whitespace shouldn't flag the
+    // field invalid or fail to recompose — `isValid` and `recompose` both trim first.
+    func test_componentValidity_hex_trimsWhitespace() {
+        let c = ColorComponent(value: "ff0000", kind: .hex, range: nil)
+        XCTAssertTrue(c.isValid("  ff0000  "))
+        XCTAssertNotNil(ColorFormat.hex.recompose(["  ff0000  "], style: .css, in: space))
+    }
+
     func test_componentValidity_decimalUnbounded() {
         let c = ColorComponent(value: "-12.5", kind: .decimal, range: nil)
         XCTAssertTrue(c.isValid("-12.5"))
         XCTAssertTrue(c.isValid("100"))
         XCTAssertFalse(c.isValid("abc"))
+    }
+
+    // `Double("inf")`/`Double("nan")` parse successfully but aren't valid colour values — a nil
+    // range (e.g. Lab a/b) wouldn't otherwise reject them, so `isValid` must check `isFinite`
+    // explicitly. Regression test for a non-finite value silently reaching `recompose`.
+    func test_componentValidity_decimalRejectsInfAndNaN() {
+        let unbounded = ColorComponent(value: "0", kind: .decimal, range: nil)
+        XCTAssertFalse(unbounded.isValid("inf"))
+        XCTAssertFalse(unbounded.isValid("-inf"))
+        XCTAssertFalse(unbounded.isValid("nan"))
+
+        let bounded = ColorComponent(value: "0", kind: .decimal, range: 0 ... 100)
+        XCTAssertFalse(bounded.isValid("inf"))
+        XCTAssertFalse(bounded.isValid("nan"))
     }
 }

--- a/PikaTests/ColorDecompositionTests.swift
+++ b/PikaTests/ColorDecompositionTests.swift
@@ -89,6 +89,28 @@ final class ColorDecompositionTests: XCTestCase {
         XCTAssertEqual(rgba.r, 1.0, accuracy: 0.01)
     }
 
+    // Regression test: the committed colour must match what `clampValuesToRange` snaps the
+    // field's displayed text to — an out-of-range Lab `l` or OKLCH `l`/`c`/`h` used to be passed
+    // straight through to `fromLab`/`fromOklch` unclamped, silently committing a colour that
+    // disagreed with the clamped value shown in the UI.
+    func test_recompose_outOfRange_clampsForLabAndOklch() {
+        let labOverRange = ColorFormat.lab.recompose(["1000", "50", "0"], style: .css, in: space)
+        let labClamped = ColorFormat.lab.recompose(["100", "50", "0"], style: .css, in: space)
+        XCTAssertNotNil(labOverRange)
+        XCTAssertEqual(
+            labOverRange?.toHex(in: .sRGB), labClamped?.toHex(in: .sRGB),
+            "an out-of-range Lab l should commit the same colour the clamped display value shows"
+        )
+
+        let oklchOverRange = ColorFormat.oklch.recompose(["50", "0.1", "400"], style: .css, in: space)
+        let oklchClamped = ColorFormat.oklch.recompose(["50", "0.1", "360"], style: .css, in: space)
+        XCTAssertNotNil(oklchOverRange)
+        XCTAssertEqual(
+            oklchOverRange?.toHex(in: .sRGB), oklchClamped?.toHex(in: .sRGB),
+            "an out-of-range OKLCH h must clamp (matching the displayed value), not wrap via cos/sin"
+        )
+    }
+
     // MARK: - ColorComponent validity
 
     func test_componentValidity_integerRange() {

--- a/PikaTests/NSColorHSLTests.swift
+++ b/PikaTests/NSColorHSLTests.swift
@@ -116,4 +116,48 @@ final class NSColorHSLTests: XCTestCase {
         let color = NSColor(hex: "3A7BD5")
         XCTAssertFalse(color.toHSLString().isEmpty)
     }
+
+    // MARK: - fromHSB / fromHSL — inverse round-trips (colorSpace pinned to sRGB in setUp)
+
+    private let roundTripSamples = ["3A7BD5", "E32C88", "00FF00", "808080", "FF8800", "123456"]
+
+    func test_fromHSB_roundTrip_matchesOriginalRGB() {
+        for hex in roundTripSamples {
+            let original = NSColor(hex: hex)
+            let hsb = original.toHSBComponents()
+            let rebuilt = NSColor.fromHSB(h: hsb.h, s: hsb.s, b: hsb.b)
+            let o = original.toRGBAComponents(in: .sRGB)
+            let r = rebuilt.toRGBAComponents(in: .sRGB)
+            XCTAssertEqual(r.r, o.r, accuracy: 0.005, "R mismatch for \(hex)")
+            XCTAssertEqual(r.g, o.g, accuracy: 0.005, "G mismatch for \(hex)")
+            XCTAssertEqual(r.b, o.b, accuracy: 0.005, "B mismatch for \(hex)")
+        }
+    }
+
+    func test_fromHSL_roundTrip_matchesOriginalRGB() {
+        for hex in roundTripSamples {
+            let original = NSColor(hex: hex)
+            let hsl = original.toHSLComponents()
+            let rebuilt = NSColor.fromHSL(h: hsl.h, s: hsl.s, l: hsl.l)
+            let o = original.toRGBAComponents(in: .sRGB)
+            let r = rebuilt.toRGBAComponents(in: .sRGB)
+            XCTAssertEqual(r.r, o.r, accuracy: 0.005, "R mismatch for \(hex)")
+            XCTAssertEqual(r.g, o.g, accuracy: 0.005, "G mismatch for \(hex)")
+            XCTAssertEqual(r.b, o.b, accuracy: 0.005, "B mismatch for \(hex)")
+        }
+    }
+
+    func test_fromHSB_zeroSaturation_isGray() {
+        let rebuilt = NSColor.fromHSB(h: 0.5, s: 0, b: 0.6).toRGBAComponents(in: .sRGB)
+        XCTAssertEqual(rebuilt.r, 0.6, accuracy: 0.005)
+        XCTAssertEqual(rebuilt.g, 0.6, accuracy: 0.005)
+        XCTAssertEqual(rebuilt.b, 0.6, accuracy: 0.005)
+    }
+
+    func test_fromHSL_zeroSaturation_isGray() {
+        let rebuilt = NSColor.fromHSL(h: 0.5, s: 0, l: 0.4).toRGBAComponents(in: .sRGB)
+        XCTAssertEqual(rebuilt.r, 0.4, accuracy: 0.005)
+        XCTAssertEqual(rebuilt.g, 0.4, accuracy: 0.005)
+        XCTAssertEqual(rebuilt.b, 0.4, accuracy: 0.005)
+    }
 }

--- a/PikaTests/NSColorInitTests.swift
+++ b/PikaTests/NSColorInitTests.swift
@@ -106,11 +106,6 @@ final class NSColorInitTests: XCTestCase {
 
     // MARK: - init(hex:) — invalid input falls back to black (never crashes)
 
-    func test_initHex_invalidLength_fallsBackToBlack() {
-        let color = NSColor(hex: "12345").toRGBAComponents(in: .sRGB)
-        XCTAssertEqual(color.r + color.g + color.b, 0.0, accuracy: 0.001)
-    }
-
     func test_initHex_nonHexCharacters_fallsBackToBlack() {
         let color = NSColor(hex: "ZZZZZZ").toRGBAComponents(in: .sRGB)
         XCTAssertEqual(color.r + color.g + color.b, 0.0, accuracy: 0.001)

--- a/PikaTests/NSColorInitTests.swift
+++ b/PikaTests/NSColorInitTests.swift
@@ -144,4 +144,17 @@ final class NSColorInitTests: XCTestCase {
         XCTAssertNil(NSColor.fromHex("GGGGGG", in: .sRGB))
         XCTAssertNil(NSColor.fromHex("12 45 6", in: .sRGB))
     }
+
+    // Regression test: leading/trailing whitespace (e.g. from pasting) must not make an
+    // otherwise-valid hex string fail to parse, and must round-trip to the same colour.
+    func test_fromHex_leadingAndTrailingWhitespace_isTrimmed() {
+        let untrimmed = NSColor.fromHex("  FF0000  ", in: .sRGB)
+        let trimmed = NSColor.fromHex("FF0000", in: .sRGB)
+        XCTAssertNotNil(untrimmed)
+        XCTAssertEqual(
+            untrimmed?.toRGBAComponents(in: .sRGB).r, trimmed?.toRGBAComponents(in: .sRGB).r
+        )
+
+        XCTAssertNotNil(NSColor.fromHex(" #00FF00 ", in: .sRGB))
+    }
 }

--- a/PikaTests/NSColorInitTests.swift
+++ b/PikaTests/NSColorInitTests.swift
@@ -103,4 +103,50 @@ final class NSColorInitTests: XCTestCase {
         XCTAssertEqual(lRGBA.g, uRGBA.g, accuracy: 0.001)
         XCTAssertEqual(lRGBA.b, uRGBA.b, accuracy: 0.001)
     }
+
+    // MARK: - init(hex:) — invalid input falls back to black (never crashes)
+
+    func test_initHex_invalidLength_fallsBackToBlack() {
+        let color = NSColor(hex: "12345").toRGBAComponents(in: .sRGB)
+        XCTAssertEqual(color.r + color.g + color.b, 0.0, accuracy: 0.001)
+    }
+
+    func test_initHex_nonHexCharacters_fallsBackToBlack() {
+        let color = NSColor(hex: "ZZZZZZ").toRGBAComponents(in: .sRGB)
+        XCTAssertEqual(color.r + color.g + color.b, 0.0, accuracy: 0.001)
+    }
+
+    // MARK: - fromHex(_:) — validating parser (nil on invalid)
+
+    func test_fromHex_valid6Char_parses() {
+        let color = NSColor.fromHex("FF0000", in: .sRGB)
+        XCTAssertNotNil(color)
+        let rgba = color!.toRGBAComponents(in: .sRGB)
+        XCTAssertEqual(rgba.r, 1.0, accuracy: 0.01)
+        XCTAssertEqual(rgba.g, 0.0, accuracy: 0.01)
+        XCTAssertEqual(rgba.b, 0.0, accuracy: 0.01)
+    }
+
+    func test_fromHex_valid3Char_expands() {
+        let short = NSColor.fromHex("F00", in: .sRGB)!.toRGBAComponents(in: .sRGB)
+        let long = NSColor.fromHex("FF0000", in: .sRGB)!.toRGBAComponents(in: .sRGB)
+        XCTAssertEqual(short.r, long.r, accuracy: 0.001)
+        XCTAssertEqual(short.g, long.g, accuracy: 0.001)
+        XCTAssertEqual(short.b, long.b, accuracy: 0.001)
+    }
+
+    func test_fromHex_withHashPrefix_parses() {
+        XCTAssertNotNil(NSColor.fromHex("#00FF00", in: .sRGB))
+    }
+
+    func test_fromHex_invalidLength_returnsNil() {
+        XCTAssertNil(NSColor.fromHex("12345", in: .sRGB))
+        XCTAssertNil(NSColor.fromHex("", in: .sRGB))
+        XCTAssertNil(NSColor.fromHex("1234567", in: .sRGB))
+    }
+
+    func test_fromHex_nonHexCharacters_returnsNil() {
+        XCTAssertNil(NSColor.fromHex("GGGGGG", in: .sRGB))
+        XCTAssertNil(NSColor.fromHex("12 45 6", in: .sRGB))
+    }
 }

--- a/PikaTests/NSColorLabTests.swift
+++ b/PikaTests/NSColorLabTests.swift
@@ -147,4 +147,52 @@ final class NSColorLabTests: XCTestCase {
                            "Token '\(token)' has trailing zeros after decimal")
         }
     }
+
+    // MARK: - fromLab(l:a:b:) — inverse round-trips
+
+    private let roundTripSamples = ["3A7BD5", "E32C88", "00FF00", "808080", "FF8800", "123456"]
+
+    func test_fromLab_roundTrip_matchesOriginalRGB() {
+        for hex in roundTripSamples {
+            let original = NSColor(hex: hex).usingColorSpace(.sRGB)!
+            let lab = original.toLabComponents()
+            let rebuilt = NSColor.fromLab(l: lab.l, a: lab.a, b: lab.b).usingColorSpace(.sRGB)!
+            let o = original.toRGBAComponents(in: .sRGB)
+            let r = rebuilt.toRGBAComponents(in: .sRGB)
+            XCTAssertEqual(r.r, o.r, accuracy: 0.01, "R mismatch for \(hex)")
+            XCTAssertEqual(r.g, o.g, accuracy: 0.01, "G mismatch for \(hex)")
+            XCTAssertEqual(r.b, o.b, accuracy: 0.01, "B mismatch for \(hex)")
+        }
+    }
+
+    func test_fromLab_white_isWhite() {
+        let rebuilt = NSColor.fromLab(l: 100, a: 0, b: 0).toRGBAComponents(in: .sRGB)
+        XCTAssertEqual(rebuilt.r, 1.0, accuracy: 0.01)
+        XCTAssertEqual(rebuilt.g, 1.0, accuracy: 0.01)
+        XCTAssertEqual(rebuilt.b, 1.0, accuracy: 0.01)
+    }
+
+    // MARK: - fromOklch(l:c:h:) — inverse round-trips
+
+    func test_fromOklch_roundTrip_matchesOriginalRGB() {
+        for hex in roundTripSamples {
+            let original = NSColor(hex: hex).usingColorSpace(.sRGB)!
+            let oklch = original.toOklchComponents()
+            let rebuilt = NSColor.fromOklch(l: oklch.l, c: oklch.c, h: oklch.h).usingColorSpace(.sRGB)!
+            let o = original.toRGBAComponents(in: .sRGB)
+            let r = rebuilt.toRGBAComponents(in: .sRGB)
+            XCTAssertEqual(r.r, o.r, accuracy: 0.01, "R mismatch for \(hex)")
+            XCTAssertEqual(r.g, o.g, accuracy: 0.01, "G mismatch for \(hex)")
+            XCTAssertEqual(r.b, o.b, accuracy: 0.01, "B mismatch for \(hex)")
+        }
+    }
+
+    func test_fromOklch_outOfGamut_clampsToValidRange() {
+        // A wildly out-of-gamut OKLCH should still produce in-[0,1] channels, not NaN/overflow.
+        let rebuilt = NSColor.fromOklch(l: 0.7, c: 0.4, h: 30).toRGBAComponents(in: .sRGB)
+        for channel in [rebuilt.r, rebuilt.g, rebuilt.b] {
+            XCTAssertGreaterThanOrEqual(channel, 0.0)
+            XCTAssertLessThanOrEqual(channel, 1.0)
+        }
+    }
 }


### PR DESCRIPTION
Turns Pika's colour readouts from display-only into a two-way control: click a value component, type, and the colour updates live. Implements `plans/in-progress/2026-08-05-inline-editable-colors.md`.

## What's here

**Model layer (fully unit-tested — 207 tests pass)**
- `NSColor.fromHex` — one validating hex parser (`nil` on invalid, no more `fatalError`); `init(hex:)` and `ColorPair` consolidate onto it.
- String→colour inverses: `fromHSB`, `fromHSL`, `fromLab`, `fromOklch` (gamut-clamped), with round-trip tests.
- `ColorFormat.decompose`/`recompose` — splits every format × copy style into fixed scaffolding + editable components and back. A parity test asserts `decompose(...).joined() == toFormat(...)` across the whole 7×4 matrix, so the editable readout renders identically to the read-only one.

**UI**
- `EditableColorValue`: dimmed non-interactive scaffolding + one focusable field per number, with four states (default / hover-fill / focus-outline / invalid-dashed).
- The value is lifted out of the pick button so field clicks edit instead of picking; type label / colour name fall through to the pick target.
- Live preview writes `eyedropper.color` per valid keystroke (posts nothing → history stays quiet); Enter or a valid blur commits and records history once via `.colorPicked`; Escape or an invalid blur reverts.
- "⚠ Invalid input" pill beside the type label.

**Toolchain (first commit)**
- Bumps KeyboardShortcuts 2.3.0 → 3.0.1 so the repo builds under Xcode 26 / Swift 6.2 (the old version had a `fileprivate extension` of a `private` enum the newer compiler rejects). CI's Xcode 16.3 was unaffected, which is why CI stayed green. The 3.x bump also isolates `onKeyUp` to `@MainActor`. This commit is included here because `origin/2.0.0` didn't have it.

## Verified
- Both "Pika" (Sparkle) and "Pika (Mac App Store)" schemes build under Xcode 26.6.
- All 207 unit tests pass on the Sparkle scheme.

## Not yet done — needs on-device QA
Interactive/visual verification couldn't run headless (`screencapture` is TCC-blocked for the debug build; it launches in menubar mode with an offscreen window). Please verify in the running app: click-to-edit focuses without picking; typing previews swatch/contrast/name live; Enter commits (one history entry); Escape reverts; blur commits-if-valid / reverts-if-invalid; the four field states + invalid pill render; Tab moves between fields. Cover each format × copy style and P3 vs sRGB.

Also outstanding: fg↔bg tab traversal isn't wired; `color.edit.invalid` is only localized in `en`; the adaptive readout is now single-line shrink-to-fit (the old 2-line wrap was dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)