### PR TITLE
Merge #258 and #259 from YuriNachos into 2.0.0

### DIFF
--- a/Pika/Extensions/LatestAppStoreVersion+ShouldUpdate.swift
+++ b/Pika/Extensions/LatestAppStoreVersion+ShouldUpdate.swift
@@ -9,7 +9,7 @@ extension LatestAppStoreVersion {
         let versionString = "\(systemVersion.majorVersion).\(systemVersion.minorVersion).\(systemVersion.patchVersion)"
 
         let isRemoteVersionHigherThanLocal = currentVersion.compare(version, options: .numeric) == .orderedAscending
-        let isSystemVersionAllowed = versionString.compare(minimumOsVersion, options: .numeric) == .orderedDescending
+        let isSystemVersionAllowed = versionString.compare(minimumOsVersion, options: .numeric) != .orderedAscending
 
         return isRemoteVersionHigherThanLocal && isSystemVersionAllowed
     }

--- a/Pika/Services/ClosestVector.swift
+++ b/Pika/Services/ClosestVector.swift
@@ -16,7 +16,10 @@ public class ClosestVector {
 
     public func compare(_ val: NSColor) -> (Int) {
         guard let color = val.usingColorSpace(.sRGB) else { return 0 }
-        let colorArr = [Int(color.redComponent * 255), Int(color.greenComponent * 255), Int(color.blueComponent * 255)]
+        // Quantise with the same rounded helper used to build the named-color
+        // database (see Eyedropper + toRGB8BitArray), so the query and the
+        // database agree on every 8-bit bucket instead of truncate-vs-round.
+        let colorArr = color.toRGB8BitArray()
 
         var minDistance = Int.max
         var index = 0

--- a/PikaTests/ClosestVectorTests.swift
+++ b/PikaTests/ClosestVectorTests.swift
@@ -69,4 +69,27 @@ final class ClosestVectorTests: XCTestCase {
         let p3Red = NSColor(colorSpace: .displayP3, components: [1.0, 0.0, 0.0, 1.0], count: 4)
         XCTAssertEqual(cv.compare(p3Red), 1)
     }
+
+    // MARK: - compare() quantisation (truncate vs round)
+
+    func test_compare_halfValueComponent_roundsNotTruncates() {
+        // The named-color database is built with round() (see toRGB8BitArray); the
+        // query must quantise the same way. 0.5 * 255 = 127.5 → round = 128,
+        // truncate = 127. With truncation the (0.5, 0.5, 0.5) query wrongly matches
+        // the [127] bucket, so the picked color is mis-named at every k.5/255 channel.
+        let cv = ClosestVector([[127, 127, 127], [128, 128, 128]])
+        let midGray = NSColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1).usingColorSpace(.sRGB)!
+        XCTAssertEqual(cv.compare(midGray), 1,
+                       "0.5-channel values must round (128) to match the database convention, not truncate (127)")
+    }
+
+    func test_compare_halfChannelAsymmetric_roundsNotTruncates() {
+        // Only the red channel sits on the 0.5 boundary (0.5 * 255 = 127.5 → round
+        // 128, truncate 127). Truncation wrongly matches the [127, 0, 0] bucket;
+        // rounding matches [128, 0, 0]. Locks the per-channel (non-gray) behaviour.
+        let cv = ClosestVector([[127, 0, 0], [128, 0, 0]])
+        let halfRed = NSColor(red: 0.5, green: 0.0, blue: 0.0, alpha: 1).usingColorSpace(.sRGB)!
+        XCTAssertEqual(cv.compare(halfRed), 1,
+                       "a single 0.5-channel must round to match the database convention")
+    }
 }


### PR DESCRIPTION
## Summary
- Combines two open fork PRs from @YuriNachos so they land in `2.0.0` as regular same-repo commits (fork PRs can't get automated review/OIDC due to GitHub's read-only token restriction on `pull_request` events from forks)
- Merges #258 — round query color to match named-color database 8-bit buckets
- Merges #259 — make the minimum-OS update gate inclusive (>=), not strict (>)

Both merged cleanly with no conflicts.

## Test plan
- [ ] CI passes on this branch
- [ ] Closes/supersedes #258 and #259 once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)